### PR TITLE
cmd: allow to override sysfs mount point

### DIFF
--- a/cmd/resource-topology-exporter/main.go
+++ b/cmd/resource-topology-exporter/main.go
@@ -58,10 +58,9 @@ const helpTemplate string = `{{.ProgramName}}
                                   sleep). [Default: 60s]
   --export-namespace=<namespace>  Namespace on which update CRDs. Use "" for all namespaces.
   --watch-namespace=<namespace>   Namespace to watch pods for. Use "" for all namespaces.
-  --sysfs=<mountpoint>            Mount point of the sysfs.
-                                  [Default: /host]
+  --sysfs=<path>                  Top-level component path of sysfs. [Default: /sys]
   --kubelet-config-file=<path>    Kubelet config file path.
-                                  [Default: /podresources/config.yaml]
+                                  [Default: /kubeletstate/config.yaml]
   --podresources-socket=<path>    Pod Resource Socket path to use.
                                   [Default: /podresources/kubelet.sock]`
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.5.2
-	github.com/jaypipes/ghw v0.8.0
+	github.com/jaypipes/ghw v0.8.1-0.20210609141030-acb1a36eaf89
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.8
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -413,8 +413,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
-github.com/jaypipes/ghw v0.8.0 h1:02q1pTm9CD83vuhBsEZZhOCS128pq87uyaQeJZkp3sQ=
-github.com/jaypipes/ghw v0.8.0/go.mod h1:+gR9bjm3W/HnFi90liF+Fj9GpCe/Dsibl9Im8KmC7c4=
+github.com/jaypipes/ghw v0.8.1-0.20210609141030-acb1a36eaf89 h1:bnu/t/cBT64OZyqRAsu9mj0+MPYipVE9XxeKyN2Bobk=
+github.com/jaypipes/ghw v0.8.1-0.20210609141030-acb1a36eaf89/go.mod h1:+gR9bjm3W/HnFi90liF+Fj9GpCe/Dsibl9Im8KmC7c4=
 github.com/jaypipes/pcidb v0.6.0 h1:VIM7GKVaW4qba30cvB67xSCgJPTzkG8Kzw/cbs5PHWU=
 github.com/jaypipes/pcidb v0.6.0/go.mod h1:L2RGk04sfRhp5wvHO0gfRAMoLY/F3PKv/nwJeVoho0o=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/pkg/resourcemonitor/noderesourcesaggregator.go
+++ b/pkg/resourcemonitor/noderesourcesaggregator.go
@@ -52,7 +52,9 @@ type resourceData struct {
 func NewResourcesAggregator(sysfsRoot string, podResourceClient podresourcesapi.PodResourcesListerClient) (ResourcesAggregator, error) {
 	var err error
 
-	topo, err := ghw.Topology(ghw.WithChroot(sysfsRoot))
+	topo, err := ghw.Topology(ghw.WithPathOverrides(ghw.PathOverrides{
+		"/sys": sysfsRoot,
+	}))
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/jaypipes/ghw/alias.go
+++ b/vendor/github.com/jaypipes/ghw/alias.go
@@ -32,9 +32,12 @@ var (
 	// match the existing environ variable to minimize surprises
 	WithDisableWarnings = option.WithNullAlerter
 	WithDisableTools    = option.WithDisableTools
+	WithPathOverrides   = option.WithPathOverrides
 )
 
 type SnapshotOptions = option.SnapshotOptions
+
+type PathOverrides = option.PathOverrides
 
 type CPUInfo = cpu.Info
 

--- a/vendor/github.com/jaypipes/ghw/pkg/context/context.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/context/context.go
@@ -19,6 +19,7 @@ type Context struct {
 	SnapshotPath         string
 	SnapshotRoot         string
 	SnapshotExclusive    bool
+	PathOverrides        option.PathOverrides
 	snapshotUnpackedPath string
 	alert                option.Alerter
 }
@@ -46,6 +47,10 @@ func New(opts ...*option.Option) *Context {
 
 	if merged.EnableTools != nil {
 		ctx.EnableTools = *merged.EnableTools
+	}
+
+	if merged.PathOverrides != nil {
+		ctx.PathOverrides = merged.PathOverrides
 	}
 
 	return ctx

--- a/vendor/github.com/jaypipes/ghw/pkg/option/option.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/option/option.go
@@ -129,6 +129,10 @@ type Option struct {
 	// EnableTools optionally request ghw to not call any external program to learn
 	// about the hardware. The default is to use such tools if available.
 	EnableTools *bool
+
+	// PathOverrides optionally allows to override the default paths ghw uses internally
+	// to learn about the system resources.
+	PathOverrides PathOverrides
 }
 
 // SnapshotOptions contains options for handling of ghw snapshots
@@ -152,6 +156,7 @@ type SnapshotOptions struct {
 	Exclusive bool
 }
 
+// WithChroot allows to override the root directory ghw uses.
 func WithChroot(dir string) *Option {
 	return &Option{Chroot: &dir}
 }
@@ -183,6 +188,16 @@ func WithDisableTools() *Option {
 	return &Option{EnableTools: &false_}
 }
 
+// PathOverrides is a map, keyed by the string name of a mount path, of override paths
+type PathOverrides map[string]string
+
+// WithPathOverrides supplies path-specific overrides for the context
+func WithPathOverrides(overrides PathOverrides) *Option {
+	return &Option{
+		PathOverrides: overrides,
+	}
+}
+
 // There is intentionally no Option related to GHW_SNAPSHOT_PRESERVE because we see that as
 // a debug/troubleshoot aid more something users wants to do regularly.
 // Hence we allow that only via the environment variable for the time being.
@@ -201,6 +216,10 @@ func Merge(opts ...*Option) *Option {
 		}
 		if opt.EnableTools != nil {
 			merged.EnableTools = opt.EnableTools
+		}
+		// intentionally only programmatically
+		if opt.PathOverrides != nil {
+			merged.PathOverrides = opt.PathOverrides
 		}
 	}
 	// Set the default value if missing from mergeOpts

--- a/vendor/github.com/jaypipes/ghw/pkg/pci/address/address.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/pci/address/address.go
@@ -17,23 +17,23 @@ var (
 	)
 )
 
+// Address contains the components of a PCI Address
 type Address struct {
 	Domain   string
 	Bus      string
-	Slot     string
+	Device   string
 	Function string
 }
 
-// String() returns the canonical [D]BSF representation of this Address
+// String() returns the canonical [D]BDF representation of this Address
 func (addr *Address) String() string {
-	return addr.Domain + ":" + addr.Bus + ":" + addr.Slot + "." + addr.Function
+	return addr.Domain + ":" + addr.Bus + ":" + addr.Device + "." + addr.Function
 }
 
-// Given a string address, returns a complete Address struct, filled in with
-// domain, bus, slot and function components. The address string may either
-// be in $BUS:$SLOT.$FUNCTION (BSF) format or it can be a full PCI address
-// that includes the 4-digit $DOMAIN information as well:
-// $DOMAIN:$BUS:$SLOT.$FUNCTION.
+// FromString returns an Address struct from an ddress string in either
+// $BUS:$DEVICE.$FUNCTION (BDF) format or it can be a full PCI address that
+// includes the 4-digit $DOMAIN information as well:
+// $DOMAIN:$BUS:$DEVICE.$FUNCTION.
 //
 // Returns "" if the address string wasn't a valid PCI address.
 func FromString(address string) *Address {
@@ -47,7 +47,7 @@ func FromString(address string) *Address {
 		return &Address{
 			Domain:   dom,
 			Bus:      matches[3],
-			Slot:     matches[4],
+			Device:   matches[4],
 			Function: matches[5],
 		}
 	}

--- a/vendor/github.com/jaypipes/ghw/pkg/pci/pci_linux.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/pci/pci_linux.go
@@ -40,7 +40,7 @@ func getDeviceModaliasPath(ctx *context.Context, address string) string {
 	}
 	return filepath.Join(
 		paths.SysBusPciDevices,
-		pciAddr.Domain+":"+pciAddr.Bus+":"+pciAddr.Slot+"."+pciAddr.Function,
+		pciAddr.String(),
 		"modalias",
 	)
 }

--- a/vendor/github.com/jaypipes/ghw/pkg/snapshot/clonetree.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/snapshot/clonetree.go
@@ -61,9 +61,9 @@ func ExpectedCloneContent() []string {
 // thus are safely represented by a static slice - e.g. they don't need to be discovered at runtime.
 func ExpectedCloneStaticContent() []string {
 	return []string{
-		"/etc/mtab",
 		"/proc/cpuinfo",
 		"/proc/meminfo",
+		"/proc/self/mounts",
 		"/sys/devices/system/cpu/cpu*/cache/index*/*",
 		"/sys/devices/system/cpu/cpu*/topology/*",
 		"/sys/devices/system/memory/block_size_bytes",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -392,7 +392,7 @@ github.com/hpcloud/tail/winfile
 github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
-# github.com/jaypipes/ghw v0.8.0
+# github.com/jaypipes/ghw v0.8.1-0.20210609141030-acb1a36eaf89
 ## explicit
 github.com/jaypipes/ghw
 github.com/jaypipes/ghw/pkg/baseboard


### PR DESCRIPTION
allow to use `/host-sys` and not force `/host/sys` (we can still do the latter).
Import ghw package which allows so.

Signed-off-by: Francesco Romani <fromani@redhat.com>