### PR TITLE
Add smart polling for RTE

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: generate manifests
       run: |
-        RTE_CONTAINER_IMAGE=${RTE_CONTAINER_IMAGE} make gen-manifests > rte-e2e.yaml
+        RTE_CONTAINER_IMAGE=${RTE_CONTAINER_IMAGE} RTE_POLL_INTERVAL=10s make gen-manifests | tee rte-e2e.yaml
 
     - name: create K8S kind cluster
       run: |
@@ -47,6 +47,13 @@ jobs:
     - name: deploy RTE
       run: |
         kubectl create -f rte-e2e.yaml
+
+    - name: cluster info
+      run: |
+        kubectl get nodes
+        kubectl get pods -A
+        kubectl describe pod -l name=resource-topology || :
+        kubectl logs -l name=resource-topology || :
 
     - name: run E2E tests
       run: |

--- a/cmd/resource-topology-exporter/main.go
+++ b/cmd/resource-topology-exporter/main.go
@@ -41,6 +41,7 @@ const helpTemplate string = `{{.ProgramName}}
 			[--export-namespace=<namespace>]
 			[--watch-namespace=<namespace>]
 			[--sysfs=<mountpoint>]
+			[--kubelet-state-dir=<path>...]
 			[--kubelet-config-file=<path>]
 
   {{.ProgramName}} -h | --help
@@ -61,6 +62,7 @@ const helpTemplate string = `{{.ProgramName}}
   --sysfs=<path>                  Top-level component path of sysfs. [Default: /sys]
   --kubelet-config-file=<path>    Kubelet config file path.
                                   [Default: /kubeletstate/config.yaml]
+  --kubelet-state-dir=<path>...   Kubelet state directory (RO access needed), for smart polling.
   --podresources-socket=<path>    Pod Resource Socket path to use.
                                   [Default: /podresources/kubelet.sock]`
 
@@ -130,6 +132,10 @@ func argsParse(argv []string) (nrtupdater.Args, resourcemonitor.Args, error) {
 	resourcemonitorArgs.SysfsRoot = arguments["--sysfs"].(string)
 	if path, ok := arguments["--podresources-socket"].(string); ok {
 		resourcemonitorArgs.PodResourceSocketPath = path
+	}
+
+	if kubeletStateDirs, ok := arguments["--kubelet-state-dir"].([]string); ok {
+		resourcemonitorArgs.KubeletStateDirs = kubeletStateDirs
 	}
 
 	return nrtupdaterArgs, resourcemonitorArgs, nil

--- a/cmd/resource-topology-exporter/main.go
+++ b/cmd/resource-topology-exporter/main.go
@@ -54,9 +54,8 @@ const helpTemplate string = `{{.ProgramName}}
                                   cluster-local Kubernetes API server.
   --hostname                      Override the node hostname.
   --oneshot                       Update once and exit.
-  --sleep-interval=<seconds>      Time to sleep between re-labeling. Non-positive
-                                  value implies no re-labeling (i.e. infinite
-                                  sleep). [Default: 60s]
+  --sleep-interval=<seconds>      Time to sleep between podresources API polls.
+                                  [Default: 60s]
   --export-namespace=<namespace>  Namespace on which update CRDs. Use "" for all namespaces.
   --watch-namespace=<namespace>   Namespace to watch pods for. Use "" for all namespaces.
   --sysfs=<path>                  Top-level component path of sysfs. [Default: /sys]

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+	github.com/fsnotify/fsnotify v1.4.9
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.5.2
 	github.com/jaypipes/ghw v0.8.1-0.20210609141030-acb1a36eaf89

--- a/hack/get-manifest-ds.sh
+++ b/hack/get-manifest-ds.sh
@@ -6,4 +6,5 @@ REPOOWNER=${REPOOWNER:-k8stopologyawarewg}
 IMAGENAME=${IMAGENAME:-resource-topology-exporter}
 IMAGETAG=${IMAGETAG:-latest}
 export RTE_CONTAINER_IMAGE=${RTE_CONTAINER_IMAGE:-quay.io/${REPOOWNER}/${IMAGENAME}:${IMAGETAG}}
+export RTE_POLL_INTERVAL="${RTE_POLL_INTERVAL:-60s}"
 envsubst < ${DIRNAME}/../manifests/resource-topology-exporter-ds.yaml

--- a/manifests/resource-topology-exporter-ds.yaml
+++ b/manifests/resource-topology-exporter-ds.yaml
@@ -47,6 +47,7 @@ spec:
         - /bin/resource-topology-exporter
         - --export-namespace=default
         - --watch-namespace=rte
+        - --sleep-interval=${RTE_POLL_INTERVAL}
         - --sysfs=/host/
         - --kubelet-config-file=/host-var/lib/kubelet/config.yaml
         - --podresources-socket=/host-var/lib/kubelet/pod-resources/kubelet.sock

--- a/pkg/resourcemonitor/types.go
+++ b/pkg/resourcemonitor/types.go
@@ -30,6 +30,7 @@ type Args struct {
 	Namespace             string
 	SysfsRoot             string
 	KubeletConfigFile     string
+	KubeletStateDirs      []string
 }
 
 type ResourceInfo struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -226,6 +226,7 @@ github.com/evanphx/json-patch
 # github.com/form3tech-oss/jwt-go v3.2.2+incompatible
 github.com/form3tech-oss/jwt-go
 # github.com/fsnotify/fsnotify v1.4.9
+## explicit
 github.com/fsnotify/fsnotify
 # github.com/ghodss/yaml v1.0.0
 ## explicit


### PR DESCRIPTION
The "smart polling" idea is all about have more polling triggers than just timer.
We know -and we can pretty much depend on- that kubelet rewrites it checkpoints for resource manager each time a resource
allocation is performed. When this happens, something changed and we can poll again the podresources API to learn what.

This allows much faster response time without the need of having a very frequent poll interval, which is too taxing on steady state.

To quickly learn about the checkpoint changes, we use the standard `fsnotify` linux API using the go package.

The only drawback of this (optional) approach is that RTE now requires RO access to the while kubelet state directory(ies).