### PR TITLE
Add more e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,6 +46,8 @@ jobs:
 
     - name: deploy RTE
       run: |
+        # TODO: what about the other workers (if any)?
+        kubectl label node kind-worker node-role.kubernetes.io/worker=''
         kubectl create -f rte-e2e.yaml
 
     - name: cluster info

--- a/Makefile
+++ b/Makefile
@@ -58,13 +58,15 @@ push: image
 test-unit:
 	go test ./pkg/...
 
-build-e2e: outdir
-	# need to use makefile rules in a better way
-	[ -x _out/rte-e2e.test ] || go test -v -c -o _out/rte-e2e.test ./test/e2e/
+.PHONY: build-e2e
+build-e2e: _out/rte-e2e.test
+
+_out/rte-e2e.test: outdir test/e2e/*.go test/e2e/utils/*.go
+	go test -v -c -o _out/rte-e2e.test ./test/e2e/
 
 .PHONY: test-e2e
 test-e2e: build-e2e
-	_out/rte-e2e.test
+	_out/rte-e2e.test -ginkgo.focus="RTE"
 
 .PHONY: test-e2e-full
 	go test -v ./test/e2e/

--- a/cmd/resource-topology-exporter/main.go
+++ b/cmd/resource-topology-exporter/main.go
@@ -35,7 +35,8 @@ func main() {
 const helpTemplate string = `{{.ProgramName}}
 
   Usage:
-  {{.ProgramName}}	[--no-publish]
+  {{.ProgramName}}	[--debug]
+                        [--no-publish]
 			[--oneshot | --sleep-interval=<seconds>]
 			[--podresources-socket=<path>]
 			[--export-namespace=<namespace>]
@@ -50,6 +51,7 @@ const helpTemplate string = `{{.ProgramName}}
 
   Options:
   -h --help                       Show this screen.
+  --debug                         Enable debug output. [Default: false]
   --version                       Output version and exit.
   --no-publish                    Do not publish discovered features to the
                                   cluster-local Kubernetes API server.
@@ -144,6 +146,7 @@ func argsParse(argv []string) (nrtupdater.Args, resourcemonitor.Args, resourceto
 		resourcemonitorArgs.KubeletStateDirs = kubeletStateDirs
 	}
 
+	rteArgs.Debug = arguments["--debug"].(bool)
 	if refCnt, ok := arguments["--reference-container"].(string); ok {
 		rteArgs.ReferenceContainer, err = resourcetopologyexporter.ContainerIdentFromString(refCnt)
 		if err != nil {

--- a/manifests/resource-topology-exporter-ds.yaml
+++ b/manifests/resource-topology-exporter-ds.yaml
@@ -46,7 +46,6 @@ spec:
         command:
         - /bin/resource-topology-exporter
         - --export-namespace=default
-        - --watch-namespace=rte
         - --sleep-interval=${RTE_POLL_INTERVAL}
         - --sysfs=/host-sys
         - --kubelet-config-file=/host-var/lib/kubelet/config.yaml

--- a/manifests/resource-topology-exporter-ds.yaml
+++ b/manifests/resource-topology-exporter-ds.yaml
@@ -48,7 +48,7 @@ spec:
         - --export-namespace=default
         - --watch-namespace=rte
         - --sleep-interval=${RTE_POLL_INTERVAL}
-        - --sysfs=/host/
+        - --sysfs=/host-sys
         - --kubelet-config-file=/host-var/lib/kubelet/config.yaml
         - --podresources-socket=/host-var/lib/kubelet/pod-resources/kubelet.sock
         env:
@@ -68,7 +68,7 @@ spec:
           value: shared-pool-container
         volumeMounts:
           - name: host-sys
-            mountPath: "/host/sys"
+            mountPath: "/host-sys"
             readOnly: true
           - name: host-conf
             mountPath: "/host-var/lib/kubelet/config.yaml"

--- a/pkg/resourcetopologyexporter/resourcetopologyexporter.go
+++ b/pkg/resourcetopologyexporter/resourcetopologyexporter.go
@@ -25,6 +25,7 @@ const (
 )
 
 type Args struct {
+	Debug              bool
 	ReferenceContainer *podrescli.ContainerIdent
 }
 
@@ -143,7 +144,7 @@ type ResourceMonitor struct {
 }
 
 func NewResourceMonitor(args resourcemonitor.Args, rteArgs Args) (*ResourceMonitor, error) {
-	podResClient, err := podrescli.NewClient(args.PodResourceSocketPath, rteArgs.ReferenceContainer)
+	podResClient, err := podrescli.NewClient(args.PodResourceSocketPath, rteArgs.Debug, rteArgs.ReferenceContainer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get podresources client: %w", err)
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -30,6 +30,12 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 )
 
+const (
+	// we rely on kind for our CI
+	defaultNodeName  = "kind-worker"
+	defaultNamespace = "default"
+)
+
 // handleFlags sets up all flags and parses the command line.
 func handleFlags() {
 	config.CopyFlags(config.Flags, flag.CommandLine)
@@ -59,4 +65,18 @@ func TestMain(m *testing.M) {
 
 func TestE2E(t *testing.T) {
 	e2ekube.RunE2ETests(t)
+}
+
+func getNodeName() string {
+	if nodeName, ok := os.LookupEnv("E2E_WORKER_NODE_NAME"); ok {
+		return nodeName
+	}
+	return defaultNodeName
+}
+
+func getNamespaceName() string {
+	if nsName, ok := os.LookupEnv("E2E_NAMESPACE_NAME"); ok {
+		return nsName
+	}
+	return defaultNamespace
 }

--- a/test/e2e/rte.go
+++ b/test/e2e/rte.go
@@ -24,22 +24,26 @@ import (
 	"context"
 	"time"
 
+	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
 	topologyclientset "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2ekubelet "k8s.io/kubernetes/test/e2e/framework/kubelet"
+
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils"
 )
 
 var _ = ginkgo.Describe("[RTE] Resource topology exporter", func() {
 	var (
+		initialized         bool
+		nodeName            string
+		namespace           string
 		topologyClient      *topologyclientset.Clientset
 		topologyUpdaterNode *v1.Node
-		kubeletConfig       *kubeletconfig.KubeletConfiguration
 	)
 
 	f := framework.NewDefaultFramework("rte")
@@ -47,42 +51,120 @@ var _ = ginkgo.Describe("[RTE] Resource topology exporter", func() {
 	ginkgo.BeforeEach(func() {
 		var err error
 
-		if topologyClient == nil {
+		if !initialized {
+			nodeName = getNodeName()
+			namespace = getNamespaceName()
+
 			topologyClient, err = topologyclientset.NewForConfig(f.ClientConfig())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			topologyUpdaterNode, err = f.ClientSet.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			workerNodes, err = utils.GetWorkerNodes(f)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			initialized = true
 		}
-
-		// TODO: hardcoded name
-		topologyUpdaterNode, err = f.ClientSet.CoreV1().Nodes().Get(context.TODO(), "kind-worker", metav1.GetOptions{})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		kubeletConfig, err = e2ekubelet.GetCurrentKubeletConfig(topologyUpdaterNode.Name, "", true)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
 	ginkgo.Context("with cluster configured", func() {
-		ginkgo.It("should fill the node resource topologies CR with the data", func() {
+		ginkgo.It("it should not account for any cpus if a container doesn't request exclusive cpus", func() {
+			ginkgo.By("getting the initial topology information")
+			initialNodeTopo := getNodeTopology(topologyClient, topologyUpdaterNode.Name, namespace)
+			ginkgo.By("creating a pod consuming the shared pool")
+			sleeperPod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sleeper-be-pod",
+				},
+				Spec: v1.PodSpec{
+					RestartPolicy: v1.RestartPolicyNever,
+					Containers: []v1.Container{
+						v1.Container{
+							Name:  "sleeper-be-cnt",
+							Image: utils.CentosImage,
+							// 1 hour (or >= 1h in general) is "forever" for our purposes
+							Command: []string{"/bin/sleep", "1h"},
+						},
+					},
+				},
+			}
+
+			podMap := make(map[string]*v1.Pod)
+			pod := f.PodClient().CreateSync(sleeperPod)
+			podMap[pod.Name] = pod
+			defer utils.DeletePodsAsync(f, podMap)
+
+			ginkgo.By("getting the updated topology")
+			// the object, hance the resource version must NOT change, so we can only sleep
+			time.Sleep(30 * time.Second)
+			ginkgo.By("checking the changes in the updated topology - expecting none")
+			finalNodeTopo := getNodeTopology(topologyClient, topologyUpdaterNode.Name, namespace)
+			gomega.Expect(finalNodeTopo.ObjectMeta.ResourceVersion).To(gomega.Equal(initialNodeTopo.ObjectMeta.ResourceVersion))
+		})
+
+		ginkgo.It("it should account for containers requesting exclusive cpus", func() {
+			ginkgo.By("getting the initial topology information")
+			initialNodeTopo := getNodeTopology(topologyClient, topologyUpdaterNode.Name, namespace)
+			ginkgo.By("creating a pod consuming the shared pool")
+			sleeperPod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sleeper-gu-pod",
+				},
+				Spec: v1.PodSpec{
+					RestartPolicy: v1.RestartPolicyNever,
+					Containers: []v1.Container{
+						v1.Container{
+							Name:  "sleeper-gu-cnt",
+							Image: utils.CentosImage,
+							// 1 hour (or >= 1h in general) is "forever" for our purposes
+							Command: []string{"/bin/sleep", "1h"},
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									// we use 1 core because that's the minimal meaningful quantity
+									v1.ResourceName(v1.ResourceCPU): resource.MustParse("1000m"),
+									// any random reasonable amount is fine
+									v1.ResourceName(v1.ResourceMemory): resource.MustParse("100Mi"),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			podMap := make(map[string]*v1.Pod)
+			pod := f.PodClient().CreateSync(sleeperPod)
+			podMap[pod.Name] = pod
+			defer utils.DeletePodsAsync(f, podMap)
+
+			ginkgo.By("getting the updated topology")
+			var finalNodeTopo *v1alpha1.NodeResourceTopology
+			var err error
 			gomega.Eventually(func() bool {
-				// TODO: we should avoid to use hardcoded namespace name
-				nodeTopology, err := topologyClient.TopologyV1alpha1().NodeResourceTopologies("default").Get(context.TODO(), topologyUpdaterNode.Name, metav1.GetOptions{})
+				finalNodeTopo, err = topologyClient.TopologyV1alpha1().NodeResourceTopologies(namespace).Get(context.TODO(), topologyUpdaterNode.Name, metav1.GetOptions{})
 				if err != nil {
 					framework.Logf("failed to get the node topology resource: %v", err)
 					return false
 				}
-
-				if nodeTopology == nil || len(nodeTopology.TopologyPolicies) == 0 {
-					framework.Logf("failed to get topology policy from the node topology resource")
-					return false
-				}
-
-				if nodeTopology.TopologyPolicies[0] != (*kubeletConfig).TopologyManagerPolicy {
-					return false
-				}
-
-				// TODO: add more checks like checking distances, NUMA node and allocated CPUs
-
-				return true
-			}, time.Minute, 5*time.Second).Should(gomega.BeTrue())
+				return finalNodeTopo.ObjectMeta.ResourceVersion != initialNodeTopo.ObjectMeta.ResourceVersion
+			}, time.Minute, 5*time.Second).Should(gomega.BeTrue(), "didn't get updated node topology info")
+			ginkgo.By("checking the changes in the updated topology")
+			// TODO
 		})
+
 	})
 })
+
+func getNodeTopology(topologyClient *topologyclientset.Clientset, nodeName, namespace string) *v1alpha1.NodeResourceTopology {
+	var nodeTopology *v1alpha1.NodeResourceTopology
+	var err error
+	gomega.EventuallyWithOffset(1, func() bool {
+		nodeTopology, err = topologyClient.TopologyV1alpha1().NodeResourceTopologies(namespace).Get(context.TODO(), nodeName, metav1.GetOptions{})
+		if err != nil {
+			framework.Logf("failed to get the node topology resource: %v", err)
+			return false
+		}
+		return true
+	}, time.Minute, 5*time.Second).Should(gomega.BeTrue())
+	return nodeTopology
+}

--- a/test/e2e/rte.go
+++ b/test/e2e/rte.go
@@ -228,17 +228,3 @@ func lessResourceList(expected, got v1.ResourceList) (string, bool) {
 	}
 	return "", false
 }
-
-func getNodeTopology(topologyClient *topologyclientset.Clientset, nodeName, namespace string) *v1alpha1.NodeResourceTopology {
-	var nodeTopology *v1alpha1.NodeResourceTopology
-	var err error
-	gomega.EventuallyWithOffset(1, func() bool {
-		nodeTopology, err = topologyClient.TopologyV1alpha1().NodeResourceTopologies(namespace).Get(context.TODO(), nodeName, metav1.GetOptions{})
-		if err != nil {
-			framework.Logf("failed to get the node topology resource: %v", err)
-			return false
-		}
-		return true
-	}, time.Minute, 5*time.Second).Should(gomega.BeTrue())
-	return nodeTopology
-}

--- a/test/e2e/utils/nodes.go
+++ b/test/e2e/utils/nodes.go
@@ -1,0 +1,71 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	// RoleWorker contains the worker role
+	RoleWorker = "worker"
+)
+
+const (
+	// LabelRole contains the key for the role label
+	LabelRole = "node-role.kubernetes.io"
+	// LabelHostname contains the key for the hostname label
+	LabelHostname = "kubernetes.io/hostname"
+)
+
+// GetWorkerNodes returns all nodes labeled as worker
+func GetWorkerNodes(f *framework.Framework) ([]v1.Node, error) {
+	return GetNodesByRole(f, RoleWorker)
+}
+
+// GetByRole returns all nodes with the specified role
+func GetNodesByRole(f *framework.Framework, role string) ([]v1.Node, error) {
+	selector, err := labels.Parse(fmt.Sprintf("%s/%s=", LabelRole, role))
+	if err != nil {
+		return nil, err
+	}
+	return GetNodesBySelector(f, selector)
+}
+
+// GetBySelector returns all nodes with the specified selector
+func GetNodesBySelector(f *framework.Framework, selector labels.Selector) ([]v1.Node, error) {
+	nodes, err := f.ClientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return nil, err
+	}
+	return nodes.Items, nil
+}
+
+// FilterNodesWithEnoughCores returns all nodes with at least the amount of given CPU allocatable
+func FilterNodesWithEnoughCores(nodes []v1.Node, cpuAmount string) ([]v1.Node, error) {
+	requestCpu := resource.MustParse(cpuAmount)
+	framework.Logf("checking request %v on %d nodes", requestCpu, len(nodes))
+
+	resNodes := []v1.Node{}
+	for _, node := range nodes {
+		availCpu, ok := node.Status.Allocatable[v1.ResourceCPU]
+		if !ok || availCpu.IsZero() {
+			return nil, fmt.Errorf("node %q has no allocatable CPU", node.Name)
+		}
+
+		if availCpu.Cmp(requestCpu) < 1 {
+			framework.Logf("node %q available cpu %v requested cpu %v", node.Name, availCpu, requestCpu)
+			continue
+		}
+
+		framework.Logf("node %q has enough resources, cluster OK", node.Name)
+		resNodes = append(resNodes, node)
+	}
+
+	return resNodes, nil
+}

--- a/test/e2e/utils/pod.go
+++ b/test/e2e/utils/pod.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+         "sync"
+
+         "github.com/onsi/ginkgo"
+
+	 v1 "k8s.io/api/core/v1"
+         metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+         "k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	CentosImage = "quay.io/centos/centos:8"
+)
+
+func DeletePodsAsync(f *framework.Framework, podMap map[string]*v1.Pod) {
+         var wg sync.WaitGroup
+         for _, pod := range podMap {
+                 wg.Add(1)
+                 go func(podNS, podName string) {
+                         defer ginkgo.GinkgoRecover()
+                         defer wg.Done()
+
+                         DeletePodSyncByName(f, podName)
+                 }(pod.Namespace, pod.Name)
+        }
+        wg.Wait()
+}
+
+func DeletePodSyncByName(f *framework.Framework, podName string) {
+        gp := int64(0)
+        delOpts := metav1.DeleteOptions{
+                GracePeriodSeconds: &gp,
+        }
+        f.PodClient().DeleteSync(podName, delOpts, framework.DefaultPodDeletionTimeout)
+}


### PR DESCRIPTION
In this series, we first split the e2e tests in rte and non-rte specific, in order to make as easy as possible to move tests from/to NFD, for the mutual benefict of both projects.
Then, we add some rte-specific e2e tests, focusing on rte-specific features like the minion-container feature or (in the future) the smart polling.
Along the way, we add minor fixes and improvements pulled by the e2e tests and the related development.