### PR TITLE
Backport excludelist

### DIFF
--- a/manifests/resource-topology-exporter-config.yaml
+++ b/manifests/resource-topology-exporter-config.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rte
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: resource-topology-exporter-config
+  namespace: rte
+data:
+  exclude-list-config.yaml: |
+    # key = node name, value = list of resources to be excluded.
+    # use * to exclude from all nodes.
+    # an example for how the exclude list should looks like
+    # excludelist:
+    #   node1: [cpu]
+    #   node2: [memory, example/deviceA]
+    #   *: [cpu]

--- a/manifests/resource-topology-exporter-ds.yaml
+++ b/manifests/resource-topology-exporter-ds.yaml
@@ -74,6 +74,8 @@ spec:
             readOnly: true
           - name: host-podresources
             mountPath: "/host-var/lib/kubelet/pod-resources"
+          - name: exclude-list-config-vol
+            mountPath: "/etc/resource-topology-exporter-config"
       - name: shared-pool-container
         image: gcr.io/google_containers/pause-amd64:3.0
       volumes:
@@ -86,3 +88,7 @@ spec:
       - name: host-podresources
         hostPath:
           path: "/var/lib/kubelet/pod-resources"
+      - name: exclude-list-config-vol
+        configMap:
+          name: resource-topology-exporter-config
+          optional: true

--- a/pkg/resourcemonitor/excludelist.go
+++ b/pkg/resourcemonitor/excludelist.go
@@ -1,0 +1,12 @@
+package resourcemonitor
+
+import "k8s.io/apimachinery/pkg/util/sets"
+
+// ToMapSet keeps the original keys, but replaces values with set.String types
+func (r *ResourceExcludeList) ToMapSet() map[string]sets.String {
+	asSet := make(map[string]sets.String)
+	for k, v := range r.ExcludeList {
+		asSet[k] = sets.NewString(v...)
+	}
+	return asSet
+}

--- a/pkg/resourcemonitor/noderesourcesaggregator.go
+++ b/pkg/resourcemonitor/noderesourcesaggregator.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -82,11 +83,19 @@ func NewResourcesAggregatorFromData(topo *ghw.TopologyInfo, resp *podresourcesap
 }
 
 // Aggregate provides the mapping (numa zone name) -> Zone from the given PodResources.
-func (noderesourceData *nodeResources) Aggregate(podResData []PodResources) topologyv1alpha1.ZoneList {
+func (noderesourceData *nodeResources) Aggregate(podResData []PodResources, excludeList ResourceExcludeList) topologyv1alpha1.ZoneList {
+	clusterNodeName := getNodeName()
+	excludeListAsSet := excludeList.ToMapSet()
 	perNuma := make(map[int]map[v1.ResourceName]*resourceData)
 	for nodeID, nodeRes := range noderesourceData.perNUMACapacity {
 		perNuma[nodeID] = make(map[v1.ResourceName]*resourceData)
 		for resName, resCap := range nodeRes {
+			if set, ok := excludeListAsSet["*"]; ok && set.Has(string(resName)) {
+				continue
+			}
+			if set, ok := excludeListAsSet[clusterNodeName]; ok && set.Has(string(resName)) {
+				continue
+			}
 			perNuma[nodeID][resName] = &resourceData{
 				capacity:    resCap,
 				allocatable: resCap,
@@ -273,4 +282,8 @@ func findNodeByID(nodes []*ghw.TopologyNode, nodeID int) *ghw.TopologyNode {
 		}
 	}
 	return nil
+}
+
+func getNodeName() string {
+	return os.Getenv("NODE_NAME")
 }

--- a/pkg/resourcemonitor/types.go
+++ b/pkg/resourcemonitor/types.go
@@ -31,6 +31,7 @@ type Args struct {
 	SysfsRoot             string
 	KubeletConfigFile     string
 	KubeletStateDirs      []string
+	ExcludeList           ResourceExcludeList
 }
 
 type ResourceInfo struct {
@@ -49,10 +50,14 @@ type PodResources struct {
 	Containers []ContainerResources
 }
 
+type ResourceExcludeList struct {
+	ExcludeList map[string][]string
+}
+
 type ResourcesScanner interface {
 	Scan() ([]PodResources, error)
 }
 
 type ResourcesAggregator interface {
-	Aggregate(podResData []PodResources) topologyv1alpha1.ZoneList
+	Aggregate(podResData []PodResources, list ResourceExcludeList) topologyv1alpha1.ZoneList
 }

--- a/pkg/resourcetopologyexporter/resourcetopologyexporter.go
+++ b/pkg/resourcetopologyexporter/resourcetopologyexporter.go
@@ -139,8 +139,9 @@ func IsTriggeringFSNotifyEvent(event fsnotify.Event) bool {
 }
 
 type ResourceMonitor struct {
-	resScan resourcemonitor.ResourcesScanner
-	resAggr resourcemonitor.ResourcesAggregator
+	resScan     resourcemonitor.ResourcesScanner
+	resAggr     resourcemonitor.ResourcesAggregator
+	excludeList resourcemonitor.ResourceExcludeList
 }
 
 func NewResourceMonitor(args resourcemonitor.Args, rteArgs Args) (*ResourceMonitor, error) {
@@ -163,8 +164,9 @@ func NewResourceMonitor(args resourcemonitor.Args, rteArgs Args) (*ResourceMonit
 	}
 
 	return &ResourceMonitor{
-		resScan: resScan,
-		resAggr: resAggr,
+		resScan:     resScan,
+		resAggr:     resAggr,
+		excludeList: args.ExcludeList,
 	}, nil
 }
 
@@ -182,7 +184,7 @@ func (rm *ResourceMonitor) Run(eventsChan <-chan struct{}) (<-chan v1alpha1.Zone
 					continue
 				}
 
-				zones := rm.resAggr.Aggregate(podResources)
+				zones := rm.resAggr.Aggregate(podResources, rm.excludeList)
 				zonesChannel <- zones
 				tsEnd := time.Now()
 


### PR DESCRIPTION
Backport the exclude-list feature from NFD.
The original PR for NFD: kubernetes-sigs/node-feature-discovery#545

For the E2E there is some problem with creating the ConfigMap during the e2e test.
The ConfigMap should be created on the cluster before the RTE container is running (the RTE container consumes the ConfigMap). this is not the case because the RTE container is up and running before the test even starts (it was created by ```kubectl create -f``` in previous steps of the CI)

Due to that, the E2E test for the ConfigMap will be added on a separate PR

Signed-off-by: Talor Itzhak <titzhak@redhat.com>