### PR TITLE
config: generalize the excludelist configuration

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: set up golang
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.16
 
     - name: build
       run: make all

--- a/config/examples/rte.yaml
+++ b/config/examples/rte.yaml
@@ -1,0 +1,5 @@
+excludelist:
+  masternode: [memory, device/exampleA]
+  workernode1: [memory, device/exampleB]
+  workernode2: [cpu]
+  "*": [device/exampleC]

--- a/manifests/resource-topology-exporter-config.yaml
+++ b/manifests/resource-topology-exporter-config.yaml
@@ -6,10 +6,10 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: resource-topology-exporter-config
-  namespace: rte
+  name: rte-config
+  namespace: default
 data:
-  exclude-list-config.yaml: |
+  config.yaml: |
     # key = node name, value = list of resources to be excluded.
     # use * to exclude from all nodes.
     # an example for how the exclude list should looks like

--- a/manifests/resource-topology-exporter-ds.yaml
+++ b/manifests/resource-topology-exporter-ds.yaml
@@ -45,8 +45,8 @@ spec:
             readOnly: true
           - name: host-kubelet-state
             mountPath: "/host-var/lib/kubelet"
-          - name: exclude-list-config-vol
-            mountPath: "/etc/resource-topology-exporter-config"
+          - name: rte-config
+            mountPath: "/etc/resource-topology-exporter"
       - name: shared-pool-container
         image: gcr.io/google_containers/pause-amd64:3.0
       volumes:
@@ -56,7 +56,7 @@ spec:
       - name: host-kubelet-state
         hostPath:
           path: "/var/lib/kubelet"
-      - name: exclude-list-config-vol
+      - name: rte-config
         configMap:
-          name: resource-topology-exporter-config
+          name: rte-config
           optional: true

--- a/manifests/resource-topology-exporter.yaml
+++ b/manifests/resource-topology-exporter.yaml
@@ -26,6 +26,21 @@ roleRef:
   name: rte
   apiGroup: rbac.authorization.k8s.io
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rte-config
+  namespace: default
+data:
+  config.yaml: |
+    # key = node name, value = list of resources to be excluded.
+    # use * to exclude from all nodes.
+    # an example for how the exclude list should looks like
+    # excludelist:
+    #   node1: [cpu]
+    #   node2: [memory, example/deviceA]
+    #   *: [cpu]
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -73,7 +88,7 @@ spec:
           - name: host-kubelet-state
             mountPath: "/host-var/lib/kubelet"
           - name: exclude-list-config-vol
-            mountPath: "/etc/resource-topology-exporter-config"
+            mountPath: "/etc/resource-topology-exporter"
       - name: shared-pool-container
         image: gcr.io/google_containers/pause-amd64:3.0
       volumes:

--- a/pkg/resourcemonitor/excludelist.go
+++ b/pkg/resourcemonitor/excludelist.go
@@ -1,6 +1,11 @@
 package resourcemonitor
 
-import "k8s.io/apimachinery/pkg/util/sets"
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
 
 // ToMapSet keeps the original keys, but replaces values with set.String types
 func (r *ResourceExcludeList) ToMapSet() map[string]sets.String {
@@ -9,4 +14,12 @@ func (r *ResourceExcludeList) ToMapSet() map[string]sets.String {
 		asSet[k] = sets.NewString(v...)
 	}
 	return asSet
+}
+
+func (r *ResourceExcludeList) String() string {
+	var b strings.Builder
+	for name, items := range r.ExcludeList {
+		fmt.Fprintf(&b, "- %s: [%s]\n", name, strings.Join(items, ", "))
+	}
+	return b.String()
 }


### PR DESCRIPTION
We generalize the option to read the exclude list from a file
into reading a full configuration file which happens to
contain the exclude list definition.

This change will allow easy expansion of the configuration
at minimal cost.

Signed-off-by: Francesco Romani <fromani@redhat.com>