### PR TITLE
Prometheus endpoint for RTE

### DIFF
--- a/cmd/resource-topology-exporter/main.go
+++ b/cmd/resource-topology-exporter/main.go
@@ -10,10 +10,12 @@ import (
 	"time"
 
 	"github.com/docopt/docopt-go"
+
 	"sigs.k8s.io/yaml"
 
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/nrtupdater"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podrescli"
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/prometheus"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcemonitor"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcetopologyexporter"
 )
@@ -32,6 +34,11 @@ func main() {
 	cli, err := podrescli.NewFilteringClient(resourcemonitorArgs.PodResourceSocketPath, rteArgs.Debug, rteArgs.ReferenceContainer)
 	if err != nil {
 		log.Fatalf("failed to get podresources client: %v", err)
+	}
+
+	err = prometheus.InitPrometheus()
+	if err != nil {
+		log.Fatalf("failed to start prometheus server: %v", err)
 	}
 
 	err = resourcetopologyexporter.Execute(cli, nrtupdaterArgs, resourcemonitorArgs, rteArgs)

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.8
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
+	github.com/prometheus/client_golang v1.11.0
 	github.com/smartystreets/assertions v1.2.0 // indirect
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/stretchr/testify v1.7.0

--- a/hack/get-manifests.sh
+++ b/hack/get-manifests.sh
@@ -7,4 +7,5 @@ IMAGENAME=${IMAGENAME:-resource-topology-exporter}
 IMAGETAG=${IMAGETAG:-latest}
 export RTE_CONTAINER_IMAGE=${RTE_CONTAINER_IMAGE:-quay.io/${REPOOWNER}/${IMAGENAME}:${IMAGETAG}}
 export RTE_POLL_INTERVAL="${RTE_POLL_INTERVAL:-60s}"
+export METRICS_PORT="${METRICS_PORT:-2112}"
 envsubst < ${DIRNAME}/../manifests/resource-topology-exporter.yaml

--- a/manifests/resource-topology-exporter-ds.yaml
+++ b/manifests/resource-topology-exporter-ds.yaml
@@ -39,6 +39,8 @@ spec:
               fieldPath: metadata.name
         - name: REFERENCE_CONTAINER_NAME
           value: shared-pool-container
+        - name: METRICS_PORT
+          value: "${METRICS_PORT}"
         volumeMounts:
           - name: host-sys
             mountPath: "/host-sys"
@@ -47,6 +49,9 @@ spec:
             mountPath: "/host-var/lib/kubelet"
           - name: rte-config
             mountPath: "/etc/resource-topology-exporter"
+        ports:
+          - name: metrics-port
+            containerPort: ${METRICS_PORT}
       - name: shared-pool-container
         image: gcr.io/google_containers/pause-amd64:3.0
       volumes:

--- a/manifests/resource-topology-exporter.yaml
+++ b/manifests/resource-topology-exporter.yaml
@@ -81,6 +81,8 @@ spec:
               fieldPath: metadata.name
         - name: REFERENCE_CONTAINER_NAME
           value: shared-pool-container
+        - name: METRICS_PORT
+          value: "${METRICS_PORT}"
         volumeMounts:
           - name: host-sys
             mountPath: "/host-sys"
@@ -89,6 +91,9 @@ spec:
             mountPath: "/host-var/lib/kubelet"
           - name: exclude-list-config-vol
             mountPath: "/etc/resource-topology-exporter"
+        ports:
+          - name: metrics-port
+            containerPort: ${METRICS_PORT}
       - name: shared-pool-container
         image: gcr.io/google_containers/pause-amd64:3.0
       volumes:

--- a/pkg/nrtupdater/nrtupdater.go
+++ b/pkg/nrtupdater/nrtupdater.go
@@ -7,12 +7,12 @@ import (
 	"os"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
-	"k8s.io/apimachinery/pkg/api/errors"
-
+	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/dumpobject"
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/prometheus"
 )
 
 const (
@@ -126,7 +126,8 @@ func (te *NRTUpdater) Run(infoChannel <-chan MonitorInfo) chan<- struct{} {
 				}
 				tsEnd := time.Now()
 
-				log.Printf("update request received at %v completed in %v", tsBegin, tsEnd.Sub(tsBegin))
+				tsDiff := tsEnd.Sub(tsBegin)
+				prometheus.UpdateOperationDelayMetric("node_resource_object_update", float64(tsDiff.Milliseconds()))
 				if te.args.Oneshot {
 					break
 				}

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -1,0 +1,85 @@
+package prometheus
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const prometheusDefaultPort = "2112"
+
+var nodeName string
+
+var (
+	PodResourceApiCallsFailure = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "podresource_api_call_failures_total",
+		Help: "The total number of podresource api calls that failed by the updater",
+	}, []string{"node", "function_name"})
+
+	OperationDelay = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "operation_delay",
+			Help: "Represent the latency of the update operation",
+		}, []string{"node", "operation_name"})
+)
+
+func getNodeName() (string, error) {
+	var err error
+
+	val, ok := os.LookupEnv("NODE_NAME")
+	if !ok {
+		val, err = os.Hostname()
+		if err != nil {
+			return "", err
+		}
+	}
+	return val, nil
+}
+
+func UpdatePodResourceApiCallsFailureMetric(funcName string) {
+	PodResourceApiCallsFailure.With(prometheus.Labels{
+		"node":      nodeName,
+		"function_name": funcName,
+	}).Inc()
+}
+
+func UpdateOperationDelayMetric(opName string, operationDelay float64) {
+	OperationDelay.With(prometheus.Labels{
+		"node": nodeName,
+		"operation_name": opName,
+	}).Set(operationDelay)
+}
+
+func InitPrometheus() error {
+	var err error
+	var port = prometheusDefaultPort
+
+	if envValue, ok := os.LookupEnv("METRICS_PORT"); ok {
+		if _, err = strconv.Atoi(envValue); err != nil {
+			return fmt.Errorf("the env variable PROMETHEUS_PORT has inccorrect value %q; err %v", envValue, err)
+		}
+		port = envValue
+	}
+
+	nodeName, err = getNodeName()
+	if err != nil {
+		return err
+	}
+
+	http.Handle("/metrics", promhttp.Handler())
+	addr := fmt.Sprintf("0.0.0.0:%s", port)
+
+	go func() {
+		if err = http.ListenAndServe(addr, nil); err != nil {
+			log.Fatalf("failed to run prometheus server; %v", err)
+		}
+	}()
+
+	return nil
+}

--- a/pkg/resourcemonitor/noderesourcesaggregator.go
+++ b/pkg/resourcemonitor/noderesourcesaggregator.go
@@ -34,6 +34,7 @@ import (
 	"github.com/jaypipes/ghw"
 
 	topologyv1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/prometheus"
 )
 
 const (
@@ -69,6 +70,7 @@ func NewResourcesAggregator(sysfsRoot string, podResourceClient podresourcesapi.
 	//Pod Resource API client
 	resp, err := podResourceClient.GetAllocatableResources(ctx, &podresourcesapi.AllocatableResourcesRequest{})
 	if err != nil {
+		prometheus.UpdatePodResourceApiCallsFailureMetric("get_allocatable_resources")
 		return nil, fmt.Errorf("Can't receive response: %v.Get(_) = _, %v", podResourceClient, err)
 	}
 

--- a/pkg/resourcemonitor/podresourcesscanner.go
+++ b/pkg/resourcemonitor/podresourcesscanner.go
@@ -21,8 +21,10 @@ import (
 	"fmt"
 	"log"
 
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
+
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/prometheus"
 )
 
 type PodResourcesScanner struct {
@@ -61,7 +63,8 @@ func (resMon *PodResourcesScanner) Scan() ([]PodResources, error) {
 	//Pod Resource API client
 	resp, err := resMon.podResourceClient.List(ctx, &podresourcesapi.ListPodResourcesRequest{})
 	if err != nil {
-		return nil, fmt.Errorf("Can't receive response: %v.Get(_) = _, %v", resMon.podResourceClient, err)
+		prometheus.UpdatePodResourceApiCallsFailureMetric("list")
+		return nil, fmt.Errorf("can't receive response: %v.Get(_) = _, %v", resMon.podResourceClient, err)
 	}
 
 	var podResData []PodResources

--- a/pkg/resourcetopologyexporter/resourcetopologyexporter.go
+++ b/pkg/resourcetopologyexporter/resourcetopologyexporter.go
@@ -15,6 +15,7 @@ import (
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/kubeconf"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/nrtupdater"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podrescli"
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/prometheus"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcemonitor"
 )
 
@@ -207,8 +208,9 @@ func (rm *ResourceMonitor) Run(eventsChan <-chan PollTrigger) (<-chan nrtupdater
 					Zones: zones,
 				}
 				tsEnd := time.Now()
+				tsDiff := tsEnd.Sub(tsBegin)
 
-				log.Printf("read request received at %v completed in %v", tsBegin, tsEnd.Sub(tsBegin))
+				prometheus.UpdateOperationDelayMetric("podresources_scan", float64(tsDiff.Milliseconds()))
 			case <-done:
 				log.Printf("read stop at %v", time.Now())
 				break

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -34,6 +34,8 @@ const (
 	// we rely on kind for our CI
 	defaultNodeName  = "kind-worker"
 	defaultNamespace = "default"
+	rteLabelName     = "resource-topology"
+	rteContainerName = "resource-topology-exporter-container"
 )
 
 // handleFlags sets up all flags and parses the command line.

--- a/test/e2e/metrics.go
+++ b/test/e2e/metrics.go
@@ -1,0 +1,53 @@
+package e2e
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = ginkgo.Describe("[RTE] metrics", func() {
+	var (
+		initialized bool
+		rtePod      *v1.Pod
+	)
+
+	f := framework.NewDefaultFramework("metrics")
+
+	ginkgo.BeforeEach(func() {
+		if !initialized {
+			pods, err := f.ClientSet.CoreV1().Pods(defaultNamespace).List(context.TODO(), metav1.ListOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			for _, pod := range pods.Items {
+				if val, ok := pod.Labels["name"]; ok && val == rteLabelName {
+					rtePod = &pod
+				}
+			}
+			gomega.Expect(rtePod).ToNot(gomega.BeNil())
+			initialized = true
+		}
+	})
+
+	ginkgo.Context("With prometheus endpoint configured", func() {
+		ginkgo.It("should have some metrics exported", func() {
+			stdout, stderr, err := f.ExecWithOptions(framework.ExecOptions{
+				Command:            []string{"curl", "http://127.0.0.1:2112/metrics"},
+				Namespace:          getNamespaceName(),
+				PodName:            rtePod.Name,
+				ContainerName:      rteContainerName,
+				Stdin:              nil,
+				CaptureStdout:      true,
+				CaptureStderr:      true,
+				PreserveWhitespace: false,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s", stderr)
+			gomega.Expect(stdout).To(gomega.ContainSubstring("operation_delay"))
+		})
+	})
+})

--- a/test/e2e/utils/pod.go
+++ b/test/e2e/utils/pod.go
@@ -39,7 +39,7 @@ func MakeGuaranteedSleeperPod(cpuLimit string) *v1.Pod {
 		Spec: v1.PodSpec{
 			RestartPolicy: v1.RestartPolicyNever,
 			Containers: []v1.Container{
-				v1.Container{
+				{
 					Name:  "sleeper-gu-cnt",
 					Image: CentosImage,
 					// 1 hour (or >= 1h in general) is "forever" for our purposes
@@ -66,7 +66,7 @@ func MakeBestEffortSleeperPod() *v1.Pod {
 		Spec: v1.PodSpec{
 			RestartPolicy: v1.RestartPolicyNever,
 			Containers: []v1.Container{
-				v1.Container{
+				{
 					Name:  "sleeper-be-cnt",
 					Image: CentosImage,
 					// 1 hour (or >= 1h in general) is "forever" for our purposes

--- a/vendor/github.com/prometheus/client_golang/prometheus/promauto/auto.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/promauto/auto.go
@@ -1,0 +1,376 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package promauto provides alternative constructors for the fundamental
+// Prometheus metric types and their …Vec and …Func variants. The difference to
+// their counterparts in the prometheus package is that the promauto
+// constructors return Collectors that are already registered with a
+// registry. There are two sets of constructors. The constructors in the first
+// set are top-level functions, while the constructors in the other set are
+// methods of the Factory type. The top-level function return Collectors
+// registered with the global registry (prometheus.DefaultRegisterer), while the
+// methods return Collectors registered with the registry the Factory was
+// constructed with. All constructors panic if the registration fails.
+//
+// The following example is a complete program to create a histogram of normally
+// distributed random numbers from the math/rand package:
+//
+//      package main
+//
+//      import (
+//              "math/rand"
+//              "net/http"
+//
+//              "github.com/prometheus/client_golang/prometheus"
+//              "github.com/prometheus/client_golang/prometheus/promauto"
+//              "github.com/prometheus/client_golang/prometheus/promhttp"
+//      )
+//
+//      var histogram = promauto.NewHistogram(prometheus.HistogramOpts{
+//              Name:    "random_numbers",
+//              Help:    "A histogram of normally distributed random numbers.",
+//              Buckets: prometheus.LinearBuckets(-3, .1, 61),
+//      })
+//
+//      func Random() {
+//              for {
+//                      histogram.Observe(rand.NormFloat64())
+//              }
+//      }
+//
+//      func main() {
+//              go Random()
+//              http.Handle("/metrics", promhttp.Handler())
+//              http.ListenAndServe(":1971", nil)
+//      }
+//
+// Prometheus's version of a minimal hello-world program:
+//
+//      package main
+//
+//      import (
+//      	"fmt"
+//      	"net/http"
+//
+//      	"github.com/prometheus/client_golang/prometheus"
+//      	"github.com/prometheus/client_golang/prometheus/promauto"
+//      	"github.com/prometheus/client_golang/prometheus/promhttp"
+//      )
+//
+//      func main() {
+//      	http.Handle("/", promhttp.InstrumentHandlerCounter(
+//      		promauto.NewCounterVec(
+//      			prometheus.CounterOpts{
+//      				Name: "hello_requests_total",
+//      				Help: "Total number of hello-world requests by HTTP code.",
+//      			},
+//      			[]string{"code"},
+//      		),
+//      		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+//      			fmt.Fprint(w, "Hello, world!")
+//      		}),
+//      	))
+//      	http.Handle("/metrics", promhttp.Handler())
+//      	http.ListenAndServe(":1971", nil)
+//      }
+//
+// A Factory is created with the With(prometheus.Registerer) function, which
+// enables two usage pattern. With(prometheus.Registerer) can be called once per
+// line:
+//
+//        var (
+//        	reg           = prometheus.NewRegistry()
+//        	randomNumbers = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+//        		Name:    "random_numbers",
+//        		Help:    "A histogram of normally distributed random numbers.",
+//        		Buckets: prometheus.LinearBuckets(-3, .1, 61),
+//        	})
+//        	requestCount = promauto.With(reg).NewCounterVec(
+//        		prometheus.CounterOpts{
+//        			Name: "http_requests_total",
+//        			Help: "Total number of HTTP requests by status code and method.",
+//        		},
+//        		[]string{"code", "method"},
+//        	)
+//        )
+//
+// Or it can be used to create a Factory once to be used multiple times:
+//
+//        var (
+//        	reg           = prometheus.NewRegistry()
+//        	factory       = promauto.With(reg)
+//        	randomNumbers = factory.NewHistogram(prometheus.HistogramOpts{
+//        		Name:    "random_numbers",
+//        		Help:    "A histogram of normally distributed random numbers.",
+//        		Buckets: prometheus.LinearBuckets(-3, .1, 61),
+//        	})
+//        	requestCount = factory.NewCounterVec(
+//        		prometheus.CounterOpts{
+//        			Name: "http_requests_total",
+//        			Help: "Total number of HTTP requests by status code and method.",
+//        		},
+//        		[]string{"code", "method"},
+//        	)
+//        )
+//
+// This appears very handy. So why are these constructors locked away in a
+// separate package?
+//
+// The main problem is that registration may fail, e.g. if a metric inconsistent
+// with or equal to the newly to be registered one is already registered.
+// Therefore, the Register method in the prometheus.Registerer interface returns
+// an error, and the same is the case for the top-level prometheus.Register
+// function that registers with the global registry. The prometheus package also
+// provides MustRegister versions for both. They panic if the registration
+// fails, and they clearly call this out by using the Must…  idiom. Panicking is
+// problematic in this case because it doesn't just happen on input provided by
+// the caller that is invalid on its own. Things are a bit more subtle here:
+// Metric creation and registration tend to be spread widely over the
+// codebase. It can easily happen that an incompatible metric is added to an
+// unrelated part of the code, and suddenly code that used to work perfectly
+// fine starts to panic (provided that the registration of the newly added
+// metric happens before the registration of the previously existing
+// metric). This may come as an even bigger surprise with the global registry,
+// where simply importing another package can trigger a panic (if the newly
+// imported package registers metrics in its init function). At least, in the
+// prometheus package, creation of metrics and other collectors is separate from
+// registration. You first create the metric, and then you decide explicitly if
+// you want to register it with a local or the global registry, and if you want
+// to handle the error or risk a panic. With the constructors in the promauto
+// package, registration is automatic, and if it fails, it will always
+// panic. Furthermore, the constructors will often be called in the var section
+// of a file, which means that panicking will happen as a side effect of merely
+// importing a package.
+//
+// A separate package allows conservative users to entirely ignore it. And
+// whoever wants to use it, will do so explicitly, with an opportunity to read
+// this warning.
+//
+// Enjoy promauto responsibly!
+package promauto
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// NewCounter works like the function of the same name in the prometheus package
+// but it automatically registers the Counter with the
+// prometheus.DefaultRegisterer. If the registration fails, NewCounter panics.
+func NewCounter(opts prometheus.CounterOpts) prometheus.Counter {
+	return With(prometheus.DefaultRegisterer).NewCounter(opts)
+}
+
+// NewCounterVec works like the function of the same name in the prometheus
+// package but it automatically registers the CounterVec with the
+// prometheus.DefaultRegisterer. If the registration fails, NewCounterVec
+// panics.
+func NewCounterVec(opts prometheus.CounterOpts, labelNames []string) *prometheus.CounterVec {
+	return With(prometheus.DefaultRegisterer).NewCounterVec(opts, labelNames)
+}
+
+// NewCounterFunc works like the function of the same name in the prometheus
+// package but it automatically registers the CounterFunc with the
+// prometheus.DefaultRegisterer. If the registration fails, NewCounterFunc
+// panics.
+func NewCounterFunc(opts prometheus.CounterOpts, function func() float64) prometheus.CounterFunc {
+	return With(prometheus.DefaultRegisterer).NewCounterFunc(opts, function)
+}
+
+// NewGauge works like the function of the same name in the prometheus package
+// but it automatically registers the Gauge with the
+// prometheus.DefaultRegisterer. If the registration fails, NewGauge panics.
+func NewGauge(opts prometheus.GaugeOpts) prometheus.Gauge {
+	return With(prometheus.DefaultRegisterer).NewGauge(opts)
+}
+
+// NewGaugeVec works like the function of the same name in the prometheus
+// package but it automatically registers the GaugeVec with the
+// prometheus.DefaultRegisterer. If the registration fails, NewGaugeVec panics.
+func NewGaugeVec(opts prometheus.GaugeOpts, labelNames []string) *prometheus.GaugeVec {
+	return With(prometheus.DefaultRegisterer).NewGaugeVec(opts, labelNames)
+}
+
+// NewGaugeFunc works like the function of the same name in the prometheus
+// package but it automatically registers the GaugeFunc with the
+// prometheus.DefaultRegisterer. If the registration fails, NewGaugeFunc panics.
+func NewGaugeFunc(opts prometheus.GaugeOpts, function func() float64) prometheus.GaugeFunc {
+	return With(prometheus.DefaultRegisterer).NewGaugeFunc(opts, function)
+}
+
+// NewSummary works like the function of the same name in the prometheus package
+// but it automatically registers the Summary with the
+// prometheus.DefaultRegisterer. If the registration fails, NewSummary panics.
+func NewSummary(opts prometheus.SummaryOpts) prometheus.Summary {
+	return With(prometheus.DefaultRegisterer).NewSummary(opts)
+}
+
+// NewSummaryVec works like the function of the same name in the prometheus
+// package but it automatically registers the SummaryVec with the
+// prometheus.DefaultRegisterer. If the registration fails, NewSummaryVec
+// panics.
+func NewSummaryVec(opts prometheus.SummaryOpts, labelNames []string) *prometheus.SummaryVec {
+	return With(prometheus.DefaultRegisterer).NewSummaryVec(opts, labelNames)
+}
+
+// NewHistogram works like the function of the same name in the prometheus
+// package but it automatically registers the Histogram with the
+// prometheus.DefaultRegisterer. If the registration fails, NewHistogram panics.
+func NewHistogram(opts prometheus.HistogramOpts) prometheus.Histogram {
+	return With(prometheus.DefaultRegisterer).NewHistogram(opts)
+}
+
+// NewHistogramVec works like the function of the same name in the prometheus
+// package but it automatically registers the HistogramVec with the
+// prometheus.DefaultRegisterer. If the registration fails, NewHistogramVec
+// panics.
+func NewHistogramVec(opts prometheus.HistogramOpts, labelNames []string) *prometheus.HistogramVec {
+	return With(prometheus.DefaultRegisterer).NewHistogramVec(opts, labelNames)
+}
+
+// NewUntypedFunc works like the function of the same name in the prometheus
+// package but it automatically registers the UntypedFunc with the
+// prometheus.DefaultRegisterer. If the registration fails, NewUntypedFunc
+// panics.
+func NewUntypedFunc(opts prometheus.UntypedOpts, function func() float64) prometheus.UntypedFunc {
+	return With(prometheus.DefaultRegisterer).NewUntypedFunc(opts, function)
+}
+
+// Factory provides factory methods to create Collectors that are automatically
+// registered with a Registerer. Create a Factory with the With function,
+// providing a Registerer to auto-register created Collectors with. The zero
+// value of a Factory creates Collectors that are not registered with any
+// Registerer. All methods of the Factory panic if the registration fails.
+type Factory struct {
+	r prometheus.Registerer
+}
+
+// With creates a Factory using the provided Registerer for registration of the
+// created Collectors. If the provided Registerer is nil, the returned Factory
+// creates Collectors that are not registered with any Registerer.
+func With(r prometheus.Registerer) Factory { return Factory{r} }
+
+// NewCounter works like the function of the same name in the prometheus package
+// but it automatically registers the Counter with the Factory's Registerer.
+func (f Factory) NewCounter(opts prometheus.CounterOpts) prometheus.Counter {
+	c := prometheus.NewCounter(opts)
+	if f.r != nil {
+		f.r.MustRegister(c)
+	}
+	return c
+}
+
+// NewCounterVec works like the function of the same name in the prometheus
+// package but it automatically registers the CounterVec with the Factory's
+// Registerer.
+func (f Factory) NewCounterVec(opts prometheus.CounterOpts, labelNames []string) *prometheus.CounterVec {
+	c := prometheus.NewCounterVec(opts, labelNames)
+	if f.r != nil {
+		f.r.MustRegister(c)
+	}
+	return c
+}
+
+// NewCounterFunc works like the function of the same name in the prometheus
+// package but it automatically registers the CounterFunc with the Factory's
+// Registerer.
+func (f Factory) NewCounterFunc(opts prometheus.CounterOpts, function func() float64) prometheus.CounterFunc {
+	c := prometheus.NewCounterFunc(opts, function)
+	if f.r != nil {
+		f.r.MustRegister(c)
+	}
+	return c
+}
+
+// NewGauge works like the function of the same name in the prometheus package
+// but it automatically registers the Gauge with the Factory's Registerer.
+func (f Factory) NewGauge(opts prometheus.GaugeOpts) prometheus.Gauge {
+	g := prometheus.NewGauge(opts)
+	if f.r != nil {
+		f.r.MustRegister(g)
+	}
+	return g
+}
+
+// NewGaugeVec works like the function of the same name in the prometheus
+// package but it automatically registers the GaugeVec with the Factory's
+// Registerer.
+func (f Factory) NewGaugeVec(opts prometheus.GaugeOpts, labelNames []string) *prometheus.GaugeVec {
+	g := prometheus.NewGaugeVec(opts, labelNames)
+	if f.r != nil {
+		f.r.MustRegister(g)
+	}
+	return g
+}
+
+// NewGaugeFunc works like the function of the same name in the prometheus
+// package but it automatically registers the GaugeFunc with the Factory's
+// Registerer.
+func (f Factory) NewGaugeFunc(opts prometheus.GaugeOpts, function func() float64) prometheus.GaugeFunc {
+	g := prometheus.NewGaugeFunc(opts, function)
+	if f.r != nil {
+		f.r.MustRegister(g)
+	}
+	return g
+}
+
+// NewSummary works like the function of the same name in the prometheus package
+// but it automatically registers the Summary with the Factory's Registerer.
+func (f Factory) NewSummary(opts prometheus.SummaryOpts) prometheus.Summary {
+	s := prometheus.NewSummary(opts)
+	if f.r != nil {
+		f.r.MustRegister(s)
+	}
+	return s
+}
+
+// NewSummaryVec works like the function of the same name in the prometheus
+// package but it automatically registers the SummaryVec with the Factory's
+// Registerer.
+func (f Factory) NewSummaryVec(opts prometheus.SummaryOpts, labelNames []string) *prometheus.SummaryVec {
+	s := prometheus.NewSummaryVec(opts, labelNames)
+	if f.r != nil {
+		f.r.MustRegister(s)
+	}
+	return s
+}
+
+// NewHistogram works like the function of the same name in the prometheus
+// package but it automatically registers the Histogram with the Factory's
+// Registerer.
+func (f Factory) NewHistogram(opts prometheus.HistogramOpts) prometheus.Histogram {
+	h := prometheus.NewHistogram(opts)
+	if f.r != nil {
+		f.r.MustRegister(h)
+	}
+	return h
+}
+
+// NewHistogramVec works like the function of the same name in the prometheus
+// package but it automatically registers the HistogramVec with the Factory's
+// Registerer.
+func (f Factory) NewHistogramVec(opts prometheus.HistogramOpts, labelNames []string) *prometheus.HistogramVec {
+	h := prometheus.NewHistogramVec(opts, labelNames)
+	if f.r != nil {
+		f.r.MustRegister(h)
+	}
+	return h
+}
+
+// NewUntypedFunc works like the function of the same name in the prometheus
+// package but it automatically registers the UntypedFunc with the Factory's
+// Registerer.
+func (f Factory) NewUntypedFunc(opts prometheus.UntypedOpts, function func() float64) prometheus.UntypedFunc {
+	u := prometheus.NewUntypedFunc(opts, function)
+	if f.r != nil {
+		f.r.MustRegister(u)
+	}
+	return u
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -557,8 +557,10 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/prometheus/client_golang v1.11.0
+## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
+github.com/prometheus/client_golang/prometheus/promauto
 github.com/prometheus/client_golang/prometheus/promhttp
 github.com/prometheus/client_golang/prometheus/testutil
 github.com/prometheus/client_golang/prometheus/testutil/promlint


### PR DESCRIPTION
This update implements a Prometheus endpoint for RTE.
It will expose two different types of metrics:
1. Number of API calls for PodresourceAPI that failed
2. A gauge that represents the latency that took every update of the NRT objects.

The server will listen on port 2112 by default