### PR TITLE
prometheus: add wakeup delay metrics

### DIFF
--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -26,6 +26,11 @@ var (
 		Name: "rte_operation_delay_milliseconds",
 		Help: "The latency between exporting stages, milliseconds",
 	}, []string{"node", "operation_name", "trigger"})
+
+	WakeupDelay = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "rte_wakeup_delay_milliseconds",
+		Help: "The wakeup delay of the monitor code, milliseconds",
+	}, []string{"node", "trigger"})
 )
 
 func getNodeName() (string, error) {
@@ -54,6 +59,13 @@ func UpdateOperationDelayMetric(opName, trigger string, operationDelay float64) 
 		"operation_name": opName,
 		"trigger":        trigger,
 	}).Set(operationDelay)
+}
+
+func UpdateWakeupDelayMetric(trigger string, wakeupDelay float64) {
+	WakeupDelay.With(prometheus.Labels{
+		"node":    nodeName,
+		"trigger": trigger,
+	}).Set(wakeupDelay)
 }
 
 func InitPrometheus() error {

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -26,7 +26,7 @@ var (
 		prometheus.GaugeOpts{
 			Name: "operation_delay",
 			Help: "Represent the latency of the update operation",
-		}, []string{"node", "operation_name"})
+		}, []string{"node", "operation_name", "trigger"})
 )
 
 func getNodeName() (string, error) {
@@ -49,10 +49,11 @@ func UpdatePodResourceApiCallsFailureMetric(funcName string) {
 	}).Inc()
 }
 
-func UpdateOperationDelayMetric(opName string, operationDelay float64) {
+func UpdateOperationDelayMetric(opName, trigger string, operationDelay float64) {
 	OperationDelay.With(prometheus.Labels{
 		"node":           nodeName,
 		"operation_name": opName,
+		"trigger":        trigger,
 	}).Set(operationDelay)
 }
 

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -18,15 +18,14 @@ var nodeName string
 
 var (
 	PodResourceApiCallsFailure = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "podresource_api_call_failures_total",
+		Name: "rte_podresource_api_call_failures_total",
 		Help: "The total number of podresource api calls that failed by the updater",
 	}, []string{"node", "function_name"})
 
-	OperationDelay = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "operation_delay",
-			Help: "Represent the latency of the update operation",
-		}, []string{"node", "operation_name", "trigger"})
+	OperationDelay = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "rte_operation_delay_milliseconds",
+		Help: "The latency between exporting stages, milliseconds",
+	}, []string{"node", "operation_name", "trigger"})
 )
 
 func getNodeName() (string, error) {

--- a/test/e2e/metrics.go
+++ b/test/e2e/metrics.go
@@ -53,8 +53,9 @@ var _ = ginkgo.Describe("[RTE] metrics", func() {
 				CaptureStderr:      true,
 				PreserveWhitespace: false,
 			})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s", stderr)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "ExecWithOptions failed with %s:\n%s", err, stderr)
 			gomega.Expect(stdout).To(gomega.ContainSubstring("operation_delay"))
+			gomega.Expect(stdout).To(gomega.ContainSubstring("podresource_api_call_failures_total"))
 		})
 	})
 })


### PR DESCRIPTION
When reporting the operation delay metric, it's useful
to track which reason we had to trigger an operation.

For node resource objects, it's easy: it's always reactive, so we
hardcode the label; for podresources scan, it could be either
reactive (smart polling) or periodic (trigger update)

Signed-off-by: Francesco Romani <fromani@redhat.com>