### PR TITLE
Unittests: Sort []ContainerDevices before comparison

### DIFF
--- a/pkg/resourcemonitor/resourcemonitor_test.go
+++ b/pkg/resourcemonitor/resourcemonitor_test.go
@@ -314,6 +314,15 @@ func TestNormalizeContainerDevices(t *testing.T) {
 				},
 			},
 		}
+
+		sort.Slice(res, func(i, j int) bool {
+			return res[i].ResourceName < res[j].ResourceName
+		})
+
+		sort.Slice(expected, func(i, j int) bool {
+			return expected[i].ResourceName < expected[j].ResourceName
+		})
+
 		log.Printf("result=%v", res)
 		log.Printf("expected=%v", expected)
 		log.Printf("diff=%s", cmp.Diff(res, expected))


### PR DESCRIPTION
In some case like can be shown here: https://github.com/k8stopologyawareschedwg/resource-topology-exporter/pull/23/checks?check_run_id=3393185481#step:5:23
the test might failed due to different order of objects between the slices.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>