### PR TITLE
Improve sorting before comparing

### DIFF
--- a/pkg/resourcemonitor/resourcemonitor_test.go
+++ b/pkg/resourcemonitor/resourcemonitor_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"log"
 	"sort"
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -316,10 +317,33 @@ func TestNormalizeContainerDevices(t *testing.T) {
 		}
 
 		sort.Slice(res, func(i, j int) bool {
+			if res[i].ResourceName == res[j].ResourceName {
+				var sbi, sbj strings.Builder
+				for _, id := range res[i].DeviceIds {
+					sbi.WriteString(id)
+				}
+
+				for _, id := range res[i].DeviceIds {
+					sbj.WriteString(id)
+				}
+				return sbi.String() < sbj.String()
+			}
 			return res[i].ResourceName < res[j].ResourceName
 		})
 
+
 		sort.Slice(expected, func(i, j int) bool {
+			if expected[i].ResourceName == expected[j].ResourceName {
+				var sbi, sbj strings.Builder
+				for _, id := range expected[i].DeviceIds {
+					sbi.WriteString(id)
+				}
+
+				for _, id := range expected[i].DeviceIds {
+					sbj.WriteString(id)
+				}
+				return sbi.String() < sbj.String()
+			}
 			return expected[i].ResourceName < expected[j].ResourceName
 		})
 


### PR DESCRIPTION
From time to time the resourcemonitor UT failed becasue the structs are equals but in different order.
Usually this is happening because the sorting of the structs isn't good enough.
In this update we added additional sort in which even if the ResourceName is identical we'll sort by DeviceIds, thus it increase the chances for both structs to look exactly the same.
If the error will still occur we'll add sort by third field and so on.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>