### PR TITLE
log: move to klog/v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	k8s.io/api v0.22.0
 	k8s.io/apimachinery v0.22.0
 	k8s.io/client-go v0.22.0
+	k8s.io/klog/v2 v2.9.0
 	k8s.io/kubelet v0.22.0
 	k8s.io/kubernetes v1.22.0
 	sigs.k8s.io/yaml v1.2.0

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -2,10 +2,11 @@ package prometheus
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"strconv"
+
+	"k8s.io/klog/v2"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -89,7 +90,7 @@ func InitPrometheus() error {
 
 	go func() {
 		if err = http.ListenAndServe(addr, nil); err != nil {
-			log.Fatalf("failed to run prometheus server; %v", err)
+			klog.Fatalf("failed to run prometheus server; %v", err)
 		}
 	}()
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1522,6 +1522,7 @@ k8s.io/cri-api/pkg/apis/runtime/v1alpha2
 k8s.io/csi-translation-lib
 k8s.io/csi-translation-lib/plugins
 # k8s.io/klog/v2 v2.9.0
+## explicit
 k8s.io/klog/v2
 # k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e
 k8s.io/kube-openapi/pkg/builder


### PR DESCRIPTION
We need a bit more powerful log package to be up to date with
best practices (most notably NFD) and to be able to toggle
messages depending on the verbosiness level.

klog is the default choice in the kube ecosystem, so we switch to it.

Signed-off-by: Francesco Romani <fromani@redhat.com>