### PR TITLE
nrtupdater: utils: align with NFD

### DIFF
--- a/pkg/nrtupdater/nrtupdater.go
+++ b/pkg/nrtupdater/nrtupdater.go
@@ -9,10 +9,10 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/yaml"
 
 	v1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/prometheus"
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/utils"
 )
 
 const (
@@ -63,7 +63,7 @@ func NewNRTUpdater(args Args, policy string) (*NRTUpdater, error) {
 }
 
 func (te *NRTUpdater) Update(info MonitorInfo) error {
-	stdoutLogger.Printf("update: sending zone: '%s'", dumpObject(info.Zones))
+	stdoutLogger.Printf("update: sending zone: '%s'", utils.Dump(info.Zones))
 
 	if te.args.NoPublish {
 		return nil
@@ -91,7 +91,7 @@ func (te *NRTUpdater) Update(info MonitorInfo) error {
 		if err != nil {
 			return fmt.Errorf("update failed to create v1alpha1.NodeResourceTopology!:%v", err)
 		}
-		log.Printf("update created CRD instance: %v", dumpObject(nrtCreated))
+		log.Printf("update created CRD instance: %v", utils.Dump(nrtCreated))
 		return nil
 	}
 
@@ -138,12 +138,4 @@ func (te *NRTUpdater) Run(infoChannel <-chan MonitorInfo) chan<- struct{} {
 		}
 	}()
 	return done
-}
-
-func dumpObject(obj interface{}) string {
-	out, err := yaml.Marshal(obj)
-	if err != nil {
-		return fmt.Sprintf("<!!! FAILED TO MARSHAL %T (%v) !!!>\n", obj, err)
-	}
-	return string(out)
 }

--- a/pkg/utils/dump.go
+++ b/pkg/utils/dump.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+// Dump dumps an object into YAML textual format
+func Dump(obj interface{}) string {
+	out, err := yaml.Marshal(obj)
+	if err != nil {
+		return fmt.Sprintf("<!!! FAILED TO MARSHAL %T (%v) !!!>\n", obj, err)
+	}
+	return string(out)
+}


### PR DESCRIPTION
Turns out that absorbing the dumpobject helper into nrtupdater
was a bad idea because it caused a needless drift from the
corresponding code from NFD. So we revert this change and
we add back a compatible code structure.

Signed-off-by: Francesco Romani <fromani@redhat.com>