### PR TITLE
version: leave "undefined" if it cannot detect

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
     - name: checkout sources
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: setup golang
       uses: actions/setup-go@v2

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,11 @@ IMAGENAME ?= resource-topology-exporter
 IMAGETAG ?= latest
 RTE_CONTAINER_IMAGE ?= quay.io/$(REPOOWNER)/$(IMAGENAME):$(IMAGETAG)
 
+LDFLAGS = -ldflags "-s -w"
 VERSION := $(shell git tag --sort=committerdate | head -n 1)
-ifeq ($(VERSION),)
-	VERSION = v0.1
-endif
-
+ifneq ($(VERSION),)
 LDFLAGS = -ldflags "-s -w -X github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/version.version=$(VERSION)"
+endif
 
 .PHONY: all
 all: build
@@ -34,7 +33,7 @@ govet:
 	go vet
 
 outdir:
-	mkdir -p _out || :
+	@mkdir -p _out || :
 
 .PHONY: deps-update
 deps-update:

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -13,10 +13,9 @@ limitations under the License.
 
 package version
 
-
 const (
 	// ProgramName is the canonical name of this program
-    ProgramName = "resource-topology-exporter"
+	ProgramName             = "resource-topology-exporter"
 	undefinedVersion string = "undefined"
 )
 


### PR DESCRIPTION
Let's avoid defaults if we cannot safely detect the version
from the git tag: otherwise we can't distinguish a legit versioned
build from a build which used the fallback.

Signed-off-by: Francesco Romani <fromani@redhat.com>