### PR TITLE
kubeletconfig: allow to get from /configz

### DIFF
--- a/pkg/kubeletconfig/configfile.go
+++ b/pkg/kubeletconfig/configfile.go
@@ -1,4 +1,20 @@
-package kubeconf
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeletconfig
 
 import (
 	"io/ioutil"

--- a/pkg/kubeletconfig/configfile_test.go
+++ b/pkg/kubeletconfig/configfile_test.go
@@ -1,4 +1,20 @@
-package kubeconf
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeletconfig
 
 import (
 	"path/filepath"

--- a/pkg/kubeletconfig/configz.go
+++ b/pkg/kubeletconfig/configz.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeletconfig
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"regexp"
+	"strconv"
+
+	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
+)
+
+func GetKubeletConfigForNodes(kc *Kubectl, nodeNames []string, logger *log.Logger) (map[string]*kubeletconfigv1beta1.KubeletConfiguration, error) {
+	cmd := kc.Command("proxy", "-p", "0")
+	stdout, stderr, err := StartWithStreamOutput(cmd)
+	defer stdout.Close()
+	defer stderr.Close()
+	defer cmd.Process.Kill()
+
+	port, err := getKubeletProxyPort(stdout)
+	if err != nil {
+		return nil, err
+	}
+	logger.Printf("proxy port: %d", port)
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+
+	kubeletConfs := make(map[string]*kubeletconfigv1beta1.KubeletConfiguration)
+	for _, nodeName := range nodeNames {
+		endpoint := fmt.Sprintf("http://127.0.0.1:%d/api/v1/nodes/%s/proxy/configz", port, nodeName)
+
+		logger.Printf("querying endpoint: %q", endpoint)
+		req, err := http.NewRequest("GET", endpoint, nil)
+		if err != nil {
+			logger.Printf("request creation failed for %q: %v - skipped", endpoint, err)
+			continue
+		}
+		req.Header.Add("Accept", "application/json")
+		resp, err := client.Do(req)
+		if err != nil {
+			logger.Printf("request execution failed for %q: %v - skipped", endpoint, err)
+			continue
+		}
+		if resp.StatusCode != 200 {
+			logger.Printf("unexpected response status code for %q: %d - skipped", endpoint, resp.StatusCode)
+			continue
+		}
+
+		conf, err := decodeConfigz(resp)
+		if err != nil {
+			logger.Printf("response decode failed for %q: %v - skipped", endpoint, err)
+			continue
+		}
+
+		kubeletConfs[nodeName] = conf
+	}
+	return kubeletConfs, nil
+}
+
+func getKubeletProxyPort(r io.Reader) (int, error) {
+	buf := make([]byte, 128)
+	n, err := r.Read(buf)
+	if err != nil {
+		return -1, err
+	}
+	output := string(buf[:n])
+	proxyRegexp, err := regexp.Compile("Starting to serve on 127.0.0.1:([0-9]+)")
+	if err != nil {
+		return -1, err
+	}
+	match := proxyRegexp.FindStringSubmatch(output)
+	return strconv.Atoi(match[1])
+}
+
+func decodeConfigz(resp *http.Response) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
+	type configzWrapper struct {
+		ComponentConfig kubeletconfigv1beta1.KubeletConfiguration `json:"kubeletconfig"`
+	}
+
+	configz := configzWrapper{}
+	contentsBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(contentsBytes, &configz)
+	if err != nil {
+		return nil, err
+	}
+
+	return &configz.ComponentConfig, nil
+}

--- a/pkg/kubeletconfig/kubectl.go
+++ b/pkg/kubeletconfig/kubectl.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeletconfig
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	DefaultKubectlPath = "/bin/kubectl"
+)
+
+type Kubectl struct {
+	logger      *log.Logger
+	kubectlPath string
+	kubeConfig  string
+	apiserver   string
+	namespace   string
+}
+
+func NewKubectl(logger *log.Logger, kubectlPath, kubeConfig string) *Kubectl {
+	return &Kubectl{
+		logger:      logger,
+		kubectlPath: kubectlPath,
+		kubeConfig:  kubeConfig,
+	}
+}
+
+func NewKubectlFromEnv(logger *log.Logger) *Kubectl {
+	kubeConfig, ok := os.LookupEnv("KUBECONFIG")
+	if !ok {
+		kubeConfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
+		logger.Printf("using default kubeconfig path: %q", kubeConfig)
+	}
+	kubectlPath, ok := os.LookupEnv("KUBECTL")
+	if !ok {
+		var err error
+		kubectlPath, err = exec.LookPath("kubectl")
+		if err != nil {
+			logger.Printf("kubectl not found (%v), falling back to hardcoded default", err)
+			kubectlPath = DefaultKubectlPath
+		}
+		logger.Printf("using kubectl path: %q", kubectlPath)
+	}
+	return NewKubectl(logger, kubectlPath, kubeConfig)
+}
+
+func (kc *Kubectl) WithAPIServer(apiserver string) *Kubectl {
+	return &Kubectl{
+		kubectlPath: kc.kubectlPath,
+		kubeConfig:  kc.kubeConfig,
+		namespace:   kc.namespace,
+		apiserver:   apiserver,
+	}
+}
+
+func (kc *Kubectl) WithNamespace(namespace string) *Kubectl {
+	return &Kubectl{
+		kubectlPath: kc.kubectlPath,
+		kubeConfig:  kc.kubeConfig,
+		apiserver:   kc.apiserver,
+		namespace:   namespace,
+	}
+}
+
+func (kc *Kubectl) IsReady() (bool, error) {
+	if _, err := os.Stat(kc.kubeConfig); err != nil {
+		return false, fmt.Errorf("invalid kubeconfig: %w", err)
+	}
+	if _, err := os.Stat(kc.kubectlPath); err != nil {
+		return false, fmt.Errorf("invalid kubectl: %w", err)
+	}
+	return true, nil
+}
+
+func (kc *Kubectl) Command(args ...string) *exec.Cmd {
+	defaultArgs := []string{
+		fmt.Sprintf("--%s=%s", clientcmd.RecommendedConfigPathFlag, kc.kubeConfig),
+	}
+	if kc.apiserver != "" {
+		fmt.Sprintf("--%s=%s", clientcmd.FlagAPIServer, kc.apiserver)
+	}
+	if kc.namespace != "" {
+		fmt.Sprintf("--namespace=%s", kc.namespace)
+	}
+	kubectlArgs := append(defaultArgs, args...)
+	kc.logger.Printf("running: %s %v", kc.kubectlPath, kubectlArgs)
+	return exec.Command(kc.kubectlPath, kubectlArgs...)
+}
+
+func StartWithStreamOutput(cmd *exec.Cmd) (stdout, stderr io.ReadCloser, err error) {
+	stdout, err = cmd.StdoutPipe()
+	if err != nil {
+		return
+	}
+	stderr, err = cmd.StderrPipe()
+	if err != nil {
+		return
+	}
+	err = cmd.Start()
+	return
+}

--- a/pkg/resourcetopologyexporter/resourcetopologyexporter.go
+++ b/pkg/resourcetopologyexporter/resourcetopologyexporter.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package resourcetopologyexporter
 
 import (
@@ -10,7 +26,7 @@ import (
 	"k8s.io/klog/v2"
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 
-	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/kubeconf"
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/kubeletconfig"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/nrtupdater"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podrescli"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/prometheus"
@@ -110,7 +126,7 @@ func getTopologyManagerPolicy(resourcemonitorArgs resourcemonitor.Args, rteArgs 
 		return rteArgs.TopologyManagerPolicy, nil
 	}
 	if rteArgs.KubeletConfigFile != "" {
-		klConfig, err := kubeconf.GetKubeletConfigFromLocalFile(rteArgs.KubeletConfigFile)
+		klConfig, err := kubeletconfig.GetKubeletConfigFromLocalFile(rteArgs.KubeletConfigFile)
 		if err != nil {
 			return "", fmt.Errorf("error getting topology Manager Policy: %w", err)
 		}


### PR DESCRIPTION
Augment and reshape the existing `kubeconf` package
to allow to get the kubelet configuration from
either a local file or the API, through a proxy.

This PR consolidates the kubelet config extraction
code from this project and
https://github.com/k8stopologyawareschedwg/deployer/tree/main/pkg/kubeletconfig

A future PR in the deployer repo will just make use
of the code here.

Signed-off-by: Francesco Romani <fromani@redhat.com>