### PR TITLE
resmon: sysinfo: add and use per-NUMA memory info

### DIFF
--- a/pkg/resourcemonitor/resourcemonitor.go
+++ b/pkg/resourcemonitor/resourcemonitor.go
@@ -216,7 +216,7 @@ func (rm *resourceMonitor) Scan(excludeList ResourceExcludeList) (topologyv1alph
 }
 
 func (rm *resourceMonitor) updateNodeCapacity() error {
-	hpCounters, err := sysinfo.GetHugepageCounters(sysinfo.Handle{}, sysinfo.GetHugepages)
+	memCounters, err := sysinfo.GetMemoryResourceCounters(sysinfo.Handle{})
 	if err != nil {
 		return err
 	}
@@ -230,8 +230,9 @@ func (rm *resourceMonitor) updateNodeCapacity() error {
 	for nodeID := range rm.topo.Nodes {
 		perNUMARc[nodeID] = resourceCounter{
 			v1.ResourceCPU:         cpuCapacity(rm.topo, nodeID),
-			v1.ResourceName(hp2Mi): hpCounters[hp2Mi][nodeID],
-			v1.ResourceName(hp1Gi): hpCounters[hp1Gi][nodeID],
+			v1.ResourceMemory:      memCounters[string(v1.ResourceMemory)][nodeID],
+			v1.ResourceName(hp2Mi): memCounters[hp2Mi][nodeID],
+			v1.ResourceName(hp1Gi): memCounters[hp1Gi][nodeID],
 		}
 	}
 	rm.nodeCapacity = perNUMARc

--- a/pkg/sysinfo/hugepages.go
+++ b/pkg/sysinfo/hugepages.go
@@ -25,27 +25,6 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const (
-	SysDevicesNode = "/sys/devices/system/node"
-)
-
-const (
-	HugepageSize2Mi = 2048
-	HugepageSize1Gi = 1048576
-)
-
-type Handle struct {
-	Root string
-}
-
-func (hnd Handle) SysDevicesNodes() string {
-	return filepath.Join(hnd.Root, SysDevicesNode)
-}
-
-func (hnd Handle) SysDevicesNodesNodeNth(nodeID int) string {
-	return filepath.Join(hnd.Root, SysDevicesNode, fmt.Sprintf("node%d", nodeID))
-}
-
 // TODO review
 type Hugepages struct {
 	NodeID int
@@ -54,27 +33,6 @@ type Hugepages struct {
 }
 
 type PerNUMACounters map[int]int64
-
-func GetHugepageCounters(hnd Handle, getHPs func(Handle) ([]*Hugepages, error)) (map[string]PerNUMACounters, error) {
-	numaCounters := make(map[string]PerNUMACounters)
-	hugepages, err := getHPs(hnd)
-	if err != nil {
-		return numaCounters, err
-	}
-
-	for _, hpage := range hugepages {
-		resourceName := HugepageResourceNameFromSize(hpage.SizeKB)
-		numaDevs, ok := numaCounters[resourceName]
-		if !ok {
-			numaDevs = make(PerNUMACounters)
-		}
-
-		numaDevs[hpage.NodeID] = int64(hpage.Total)
-		numaCounters[resourceName] = numaDevs
-	}
-
-	return numaCounters, nil
-}
 
 func GetHugepages(hnd Handle) ([]*Hugepages, error) {
 	entries, err := ioutil.ReadDir(hnd.SysDevicesNodes())

--- a/pkg/sysinfo/hugepages_test.go
+++ b/pkg/sysinfo/hugepages_test.go
@@ -75,7 +75,7 @@ func TestHugepagesForNode(t *testing.T) {
 		t.Errorf("failed to setup hugepages on node %d the fake tree on %q: %v", 0, rootDir, err)
 	}
 
-	hpCounters, err := GetHugepageCounters(Handle{rootDir}, GetHugepages)
+	hpCounters, err := GetMemoryResourceCounters(Handle{rootDir})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/pkg/sysinfo/memory.go
+++ b/pkg/sysinfo/memory.go
@@ -1,0 +1,91 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sysinfo
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"k8s.io/klog/v2"
+)
+
+func GetMemory(hnd Handle) (map[int]int64, error) {
+	entries, err := ioutil.ReadDir(hnd.SysDevicesNodes())
+	if err != nil {
+		return nil, err
+	}
+
+	memory := map[int]int64{}
+	for _, entry := range entries {
+		entryName := entry.Name()
+		if entry.IsDir() && strings.HasPrefix(entryName, "node") {
+			nodeID, err := strconv.Atoi(entryName[4:])
+			if err != nil {
+				klog.Warningf("cannot detect the node ID for %q", entryName)
+				continue
+			}
+			nodeMemory, err := MemoryForNode(hnd, nodeID)
+			if err != nil {
+				klog.Warningf("cannot find the memory on NUMA node %d: %v", nodeID, err)
+				continue
+			}
+			memory[nodeID] = nodeMemory
+		}
+	}
+	return memory, nil
+}
+
+func MemoryForNode(hnd Handle, nodeID int) (int64, error) {
+	path := filepath.Join(
+		hnd.SysDevicesNodesNodeNth(nodeID),
+		"meminfo",
+	)
+
+	value, err := readTotalMemoryFromMeminfo(path)
+	if err != nil {
+		return -1, err
+	}
+
+	return value, nil
+}
+
+func readTotalMemoryFromMeminfo(path string) (int64, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return -1, err
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.Contains(line, "MemTotal") {
+			continue
+		}
+
+		memTotal := strings.Split(line, ":")
+		if len(memTotal) != 2 {
+			return -1, fmt.Errorf("MemTotal has unexpected format: %s", line)
+		}
+
+		memValue := strings.Trim(memTotal[1], "\t\n kB")
+		convertedValue, err := strconv.ParseInt(memValue, 10, 64)
+		if err != nil {
+			return -1, fmt.Errorf("failed to convert value: %v", memValue)
+		}
+
+		return 1024 * convertedValue, nil
+	}
+
+	return -1, fmt.Errorf("failed to find MemTotal field under the file %q", path)
+}

--- a/pkg/sysinfo/memory_test.go
+++ b/pkg/sysinfo/memory_test.go
@@ -1,0 +1,96 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sysinfo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+const testMeminfo = `Node 0 MemTotal:       32718644 kB
+Node 0 MemFree:         2915988 kB
+Node 0 MemUsed:        29802656 kB
+Node 0 Active:         19631832 kB
+Node 0 Inactive:        8089096 kB
+Node 0 Active(anon):   10104396 kB
+Node 0 Inactive(anon):   511432 kB
+Node 0 Active(file):    9527436 kB
+Node 0 Inactive(file):  7577664 kB
+Node 0 Unevictable:      637864 kB
+Node 0 Mlocked:               0 kB
+Node 0 Dirty:              1140 kB
+Node 0 Writeback:             0 kB
+Node 0 FilePages:      18206092 kB
+Node 0 Mapped:          2000244 kB
+Node 0 AnonPages:      10152780 kB
+Node 0 Shmem:           1249348 kB
+Node 0 KernelStack:       37440 kB
+Node 0 PageTables:       110460 kB
+Node 0 NFS_Unstable:          0 kB
+Node 0 Bounce:                0 kB
+Node 0 WritebackTmp:          0 kB
+Node 0 KReclaimable:     843624 kB
+Node 0 Slab:            1198060 kB
+Node 0 SReclaimable:     843624 kB
+Node 0 SUnreclaim:       354436 kB
+Node 0 AnonHugePages:     26624 kB
+Node 0 ShmemHugePages:        0 kB
+Node 0 ShmemPmdMapped:        0 kB
+Node 0 FileHugePages:        0 kB
+Node 0 FilePmdMapped:        0 kB
+Node 0 HugePages_Total:     0
+Node 0 HugePages_Free:      0
+Node 0 HugePages_Surp:      0`
+
+func TestMemoryForNode(t *testing.T) {
+	rootDir, err := os.MkdirTemp("", "fakememory")
+	if err != nil {
+		t.Errorf("failed to create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(rootDir) // clean up
+
+	if err := makeMemoryTree(rootDir, 2); err != nil {
+		t.Errorf("failed to setup the fake tree on %q: %v", rootDir, err)
+	}
+
+	memResource := string(v1.ResourceMemory)
+	memoryCounters, err := GetMemoryResourceCounters(Handle{rootDir})
+	if memoryCounters["memory"][0] != 32718644*1024 {
+		t.Errorf("found unexpected amount of memory under the NUMA node 0: %d", memoryCounters[memResource][0])
+	}
+
+	if memoryCounters["memory"][1] != 32718644*1024 {
+		t.Errorf("found unexpected amount of memory under the NUMA node 1: %d", memoryCounters[memResource][1])
+	}
+}
+
+func makeMemoryTree(root string, numNodes int) error {
+	hnd := Handle{root}
+	for idx := 0; idx < numNodes; idx++ {
+		if err := os.MkdirAll(hnd.SysDevicesNodesNodeNth(idx), 0755); err != nil {
+			return err
+		}
+		path := filepath.Join(
+			hnd.SysDevicesNodesNodeNth(idx),
+			"meminfo",
+		)
+		if err := os.WriteFile(path, []byte(testMeminfo), 0644); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -1,0 +1,77 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sysinfo
+
+import (
+	"fmt"
+	"path/filepath"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	SysDevicesNode = "/sys/devices/system/node"
+)
+
+const (
+	HugepageSize2Mi = 2048
+	HugepageSize1Gi = 1048576
+)
+
+type Handle struct {
+	Root string
+}
+
+func (hnd Handle) SysDevicesNodes() string {
+	return filepath.Join(hnd.Root, SysDevicesNode)
+}
+
+func (hnd Handle) SysDevicesNodesNodeNth(nodeID int) string {
+	return filepath.Join(hnd.Root, SysDevicesNode, fmt.Sprintf("node%d", nodeID))
+}
+
+func GetMemoryResourceCounters(hnd Handle) (map[string]PerNUMACounters, error) {
+	memResource := string(v1.ResourceMemory)
+	numaCounters := map[string]PerNUMACounters{
+		memResource: make(PerNUMACounters),
+	}
+
+	hugepages, err := GetHugepages(hnd)
+	if err != nil {
+		return numaCounters, err
+	}
+
+	for _, hpage := range hugepages {
+		resourceName := HugepageResourceNameFromSize(hpage.SizeKB)
+		numaDevs, ok := numaCounters[resourceName]
+		if !ok {
+			numaDevs = make(PerNUMACounters)
+		}
+
+		numaDevs[hpage.NodeID] = int64(hpage.Total)
+		numaCounters[resourceName] = numaDevs
+	}
+
+	memory, err := GetMemory(hnd)
+	if err != nil {
+		return numaCounters, err
+	}
+
+	for numaID, value := range memory {
+		numaCounters[memResource][numaID] = value
+	}
+
+	return numaCounters, nil
+}


### PR DESCRIPTION
Extend the sysinfo package to extract per-NUMA memory information, and report it as per-NUMA capacity in resource monitor.