### PR TITLE
e2e: modularize the suite

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -28,6 +28,9 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/config"
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
+
+	_ "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/rte"
+	_ "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/topology_updater"
 )
 
 // handleFlags sets up all flags and parses the command line.

--- a/test/e2e/rte/metrics.go
+++ b/test/e2e/rte/metrics.go
@@ -1,4 +1,24 @@
-package e2e
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ * resource-topology-exporter specific tests
+ */
+
+package rte
 
 import (
 	"context"
@@ -11,6 +31,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
+
+	e2etestenv "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/testenv"
 )
 
 var _ = ginkgo.Describe("[RTE] metrics", func() {
@@ -27,9 +49,9 @@ var _ = ginkgo.Describe("[RTE] metrics", func() {
 			var err error
 			var pods *corev1.PodList
 			sel := metav1.LabelSelector{
-				MatchLabels: map[string]string{"name": rteLabelName},
+				MatchLabels: map[string]string{"name": e2etestenv.RTELabelName},
 			}
-			pods, err = f.ClientSet.CoreV1().Pods(defaultNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: sel.String()})
+			pods, err = f.ClientSet.CoreV1().Pods(e2etestenv.DefaultNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: sel.String()})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			gomega.Expect(len(pods.Items)).To(gomega.Equal(1))
@@ -47,7 +69,7 @@ var _ = ginkgo.Describe("[RTE] metrics", func() {
 				Command:            []string{"curl", fmt.Sprintf("http://127.0.0.1:%d/metrics", metricsPort)},
 				Namespace:          rtePod.Namespace,
 				PodName:            rtePod.Name,
-				ContainerName:      rteContainerName,
+				ContainerName:      e2etestenv.RTEContainerName,
 				Stdin:              nil,
 				CaptureStdout:      true,
 				CaptureStderr:      true,

--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -18,12 +18,11 @@ limitations under the License.
  * resource-topology-exporter specific tests
  */
 
-package e2e
+package rte
 
 import (
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -41,7 +40,12 @@ import (
 	topologyclientset "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/nrtupdater"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/version"
+
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils"
+	e2enodes "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/nodes"
+	e2enodetopology "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/nodetopology"
+	e2epods "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/pods"
+	e2etestenv "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/testenv"
 )
 
 const (
@@ -66,8 +70,8 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 		var err error
 
 		if !initialized {
-			nodeName = utils.GetNodeName()
-			namespace = getNamespaceName()
+			nodeName = e2etestenv.GetNodeName()
+			namespace = e2etestenv.GetNamespaceName()
 
 			topologyClient, err = topologyclientset.NewForConfig(f.ClientConfig())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -75,7 +79,7 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 			topologyUpdaterNode, err = f.ClientSet.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			workerNodes, err = utils.GetWorkerNodes(f)
+			workerNodes, err = e2enodes.GetWorkerNodes(f)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			initialized = true
@@ -84,20 +88,20 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 
 	ginkgo.Context("with cluster configured", func() {
 		ginkgo.It("it should react to pod changes using the smart poller", func() {
-			nodes, err := utils.FilterNodesWithEnoughCores(workerNodes, "1000m")
+			nodes, err := e2enodes.FilterNodesWithEnoughCores(workerNodes, "1000m")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			if len(nodes) < 1 {
 				ginkgo.Skip("not enough allocatable cores for this test")
 			}
 
-			initialNodeTopo := getNodeTopology(topologyClient, topologyUpdaterNode.Name, namespace)
+			initialNodeTopo := e2enodetopology.GetNodeTopology(topologyClient, topologyUpdaterNode.Name, namespace)
 			ginkgo.By("creating a pod consuming the shared pool")
-			sleeperPod := utils.MakeGuaranteedSleeperPod("1000m")
+			sleeperPod := e2epods.MakeGuaranteedSleeperPod("1000m")
 
 			podMap := make(map[string]*v1.Pod)
 			pod := f.PodClient().CreateSync(sleeperPod)
 			podMap[pod.Name] = pod
-			defer utils.DeletePodsAsync(f, podMap)
+			defer e2epods.DeletePodsAsync(f, podMap)
 
 			ginkgo.By("getting the updated topology")
 			var finalNodeTopo *v1alpha1.NodeResourceTopology
@@ -136,76 +140,3 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 		})
 	})
 })
-
-func availableResourceListFromNodeResourceTopology(nodeTopo *v1alpha1.NodeResourceTopology) map[string]v1.ResourceList {
-	availRes := make(map[string]v1.ResourceList)
-	for _, zone := range nodeTopo.Zones {
-		if zone.Type != "Node" {
-			continue
-		}
-		resList := make(v1.ResourceList)
-		for _, res := range zone.Resources {
-			resList[v1.ResourceName(res.Name)] = res.Available
-		}
-		if len(resList) == 0 {
-			continue
-		}
-		availRes[zone.Name] = resList
-	}
-	return availRes
-}
-
-func lessAvailableResources(expected, got map[string]v1.ResourceList) (string, string, bool) {
-	zoneName, resName, cmp, ok := cmpAvailableResources(expected, got)
-	if !ok {
-		framework.Logf("-> cmp failed (not ok)")
-		return "", "", false
-	}
-	if cmp < 0 {
-		return zoneName, resName, true
-	}
-	framework.Logf("-> cmp failed (value=%d)", cmp)
-	return "", "", false
-}
-
-func cmpAvailableResources(expected, got map[string]v1.ResourceList) (string, string, int, bool) {
-	if len(got) != len(expected) {
-		framework.Logf("-> expected=%v (len=%d) got=%v (len=%d)", expected, len(expected), got, len(got))
-		return "", "", 0, false
-	}
-	for expZoneName, expResList := range expected {
-		gotResList, ok := got[expZoneName]
-		if !ok {
-			return expZoneName, "", 0, false
-		}
-		if resName, cmp, ok := cmpResourceList(expResList, gotResList); !ok || cmp != 0 {
-			return expZoneName, resName, cmp, ok
-		}
-	}
-	return "", "", 0, true
-}
-
-func cmpResourceList(expected, got v1.ResourceList) (string, int, bool) {
-	if len(got) != len(expected) {
-		framework.Logf("-> expected=%v (len=%d) got=%v (len=%d)", expected, len(expected), got, len(got))
-		return "", 0, false
-	}
-	for expResName, expResQty := range expected {
-		gotResQty, ok := got[expResName]
-		if !ok {
-			return string(expResName), 0, false
-		}
-		if cmp := gotResQty.Cmp(expResQty); cmp != 0 {
-			framework.Logf("-> resource=%q cmp=%d expected=%v got=%v", expResName, cmp, expResQty, gotResQty)
-			return string(expResName), cmp, true
-		}
-	}
-	return "", 0, true
-}
-
-func getNamespaceName() string {
-	if nsName, ok := os.LookupEnv("E2E_NAMESPACE_NAME"); ok {
-		return nsName
-	}
-	return defaultNamespace
-}

--- a/test/e2e/utils/nodes/nodes.go
+++ b/test/e2e/utils/nodes/nodes.go
@@ -1,14 +1,30 @@
-package utils
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodes
 
 import (
 	"context"
 	"fmt"
-	"os"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -71,11 +87,4 @@ func FilterNodesWithEnoughCores(nodes []v1.Node, cpuAmount string) ([]v1.Node, e
 	}
 
 	return resNodes, nil
-}
-
-func GetNodeName() string {
-	if nodeName, ok := os.LookupEnv("E2E_WORKER_NODE_NAME"); ok {
-		return nodeName
-	}
-	return DefaultNodeName
 }

--- a/test/e2e/utils/nodetopology/nodetopology.go
+++ b/test/e2e/utils/nodetopology/nodetopology.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodetopology
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
+	topologyclientset "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned"
+	"github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func GetNodeTopology(topologyClient *topologyclientset.Clientset, nodeName, namespace string) *v1alpha1.NodeResourceTopology {
+	var nodeTopology *v1alpha1.NodeResourceTopology
+	var err error
+	gomega.EventuallyWithOffset(1, func() bool {
+		nodeTopology, err = topologyClient.TopologyV1alpha1().NodeResourceTopologies(namespace).Get(context.TODO(), nodeName, metav1.GetOptions{})
+		if err != nil {
+			framework.Logf("failed to get the node topology resource: %v", err)
+			return false
+		}
+		return true
+	}, time.Minute, 5*time.Second).Should(gomega.BeTrue())
+	return nodeTopology
+}
+
+func IsValidNodeTopology(nodeTopology *v1alpha1.NodeResourceTopology, kubeletConfig *kubeletconfig.KubeletConfiguration) bool {
+	if nodeTopology == nil || len(nodeTopology.TopologyPolicies) == 0 {
+		framework.Logf("failed to get topology policy from the node topology resource")
+		return false
+	}
+
+	if kubeletConfig != nil {
+		if nodeTopology.TopologyPolicies[0] != (*kubeletConfig).TopologyManagerPolicy {
+			return false
+		}
+	}
+
+	if nodeTopology.Zones == nil || len(nodeTopology.Zones) == 0 {
+		framework.Logf("failed to get topology zones from the node topology resource")
+		return false
+	}
+
+	foundNodes := 0
+	for _, zone := range nodeTopology.Zones {
+		// TODO constant not in the APIs
+		if !strings.HasPrefix(strings.ToUpper(zone.Type), "NODE") {
+			continue
+		}
+		foundNodes++
+
+		if !IsValidCostList(zone.Name, zone.Costs) {
+			return false
+		}
+
+		if !IsValidResourceList(zone.Name, zone.Resources) {
+			return false
+		}
+	}
+	return foundNodes > 0
+}
+
+func IsValidCostList(zoneName string, costs v1alpha1.CostList) bool {
+	if len(costs) == 0 {
+		framework.Logf("failed to get topology costs for zone %q from the node topology resource", zoneName)
+		return false
+	}
+
+	// TODO cross-validate zone names
+	for _, cost := range costs {
+		if cost.Name == "" || cost.Value < 0 {
+			framework.Logf("malformed cost %v for zone %q", cost, zoneName)
+		}
+	}
+	return true
+}
+
+func IsValidResourceList(zoneName string, resources v1alpha1.ResourceInfoList) bool {
+	if len(resources) == 0 {
+		framework.Logf("failed to get topology resources for zone %q from the node topology resource", zoneName)
+		return false
+	}
+	foundCpu := false
+	for _, resource := range resources {
+		// TODO constant not in the APIs
+		if strings.ToUpper(resource.Name) == "CPU" {
+			foundCpu = true
+		}
+		available := resource.Available.Value()
+		allocatable := resource.Capacity.Value()
+		capacity := resource.Capacity.Value()
+		if (available < 0 || allocatable < 0 || capacity < 0) || (capacity < available) || (capacity < allocatable) {
+			framework.Logf("malformed resource %v for zone %q", resource, zoneName)
+			return false
+		}
+	}
+	return foundCpu
+}
+
+func AvailableResourceListFromNodeResourceTopology(nodeTopo *v1alpha1.NodeResourceTopology) map[string]v1.ResourceList {
+	availRes := make(map[string]v1.ResourceList)
+	for _, zone := range nodeTopo.Zones {
+		if zone.Type != "Node" {
+			continue
+		}
+		resList := make(v1.ResourceList)
+		for _, res := range zone.Resources {
+			resList[v1.ResourceName(res.Name)] = res.Available
+		}
+		if len(resList) == 0 {
+			continue
+		}
+		availRes[zone.Name] = resList
+	}
+	return availRes
+}
+
+func LessAvailableResources(expected, got map[string]v1.ResourceList) (string, string, bool) {
+	zoneName, resName, cmp, ok := CmpAvailableResources(expected, got)
+	if !ok {
+		framework.Logf("-> cmp failed (not ok)")
+		return "", "", false
+	}
+	if cmp < 0 {
+		return zoneName, resName, true
+	}
+	framework.Logf("-> cmp failed (value=%d)", cmp)
+	return "", "", false
+}
+
+func CmpAvailableResources(expected, got map[string]v1.ResourceList) (string, string, int, bool) {
+	if len(got) != len(expected) {
+		framework.Logf("-> expected=%v (len=%d) got=%v (len=%d)", expected, len(expected), got, len(got))
+		return "", "", 0, false
+	}
+	for expZoneName, expResList := range expected {
+		gotResList, ok := got[expZoneName]
+		if !ok {
+			return expZoneName, "", 0, false
+		}
+		if resName, cmp, ok := CmpResourceList(expResList, gotResList); !ok || cmp != 0 {
+			return expZoneName, resName, cmp, ok
+		}
+	}
+	return "", "", 0, true
+}
+
+func CmpResourceList(expected, got v1.ResourceList) (string, int, bool) {
+	if len(got) != len(expected) {
+		framework.Logf("-> expected=%v (len=%d) got=%v (len=%d)", expected, len(expected), got, len(got))
+		return "", 0, false
+	}
+	for expResName, expResQty := range expected {
+		gotResQty, ok := got[expResName]
+		if !ok {
+			return string(expResName), 0, false
+		}
+		if cmp := gotResQty.Cmp(expResQty); cmp != 0 {
+			framework.Logf("-> resource=%q cmp=%d expected=%v got=%v", expResName, cmp, expResQty, gotResQty)
+			return string(expResName), cmp, true
+		}
+	}
+	return "", 0, true
+}

--- a/test/e2e/utils/pods/pods.go
+++ b/test/e2e/utils/pods/pods.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package pods
 
 import (
 	"sync"

--- a/test/e2e/utils/testenv/testenv.go
+++ b/test/e2e/utils/testenv/testenv.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testenv
+
+import (
+	"os"
+)
+
+const (
+	// we rely on kind for our CI
+	DefaultNodeName  = "kind-worker"
+	DefaultNamespace = "default"
+	RTELabelName     = "resource-topology"
+	RTEContainerName = "resource-topology-exporter-container"
+)
+
+func GetNodeName() string {
+	if nodeName, ok := os.LookupEnv("E2E_WORKER_NODE_NAME"); ok {
+		return nodeName
+	}
+	return DefaultNodeName
+}
+
+func GetNamespaceName() string {
+	if nsName, ok := os.LookupEnv("E2E_NAMESPACE_NAME"); ok {
+		return nsName
+	}
+	return DefaultNamespace
+}


### PR DESCRIPTION
In this PR we modularize the test suite to make it as easy
as possible to consume.
This will allow the external project to consume the suite.
More projects consuming our suite will make it run more often,
so we will have more coverage, so we will have less bugs.

This PR is only about renaming and code moving, so the
chances of breakage are actually pretty low.

Signed-off-by: Francesco Romani <fromani@redhat.com>