### PR TITLE
test: e2e: split test which require local resources

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,7 +68,7 @@ jobs:
     - name: run E2E tests
       run: |
         export KUBECONFIG=${HOME}/.kube/config 
-        _out/rte-e2e.test -ginkgo.focus='\[(RTE|TopologyUpdater)\].*\[InfraConsuming\]'
+        _out/rte-e2e.test -ginkgo.focus='\[(RTE|TopologyUpdater)\].*\[(Local|InfraConsuming)\]'
 
   e2e-ip:
     runs-on: ubuntu-20.04

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 
 	_ "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/rte"
+	_ "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/rte_local"
 	_ "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/topology_updater"
 )
 

--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -22,13 +22,8 @@ package rte
 
 import (
 	"context"
-	"fmt"
-	"os/exec"
-	"path/filepath"
-	"strings"
 	"time"
 
-	goversion "github.com/hashicorp/go-version"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 
@@ -39,9 +34,6 @@ import (
 	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
 	topologyclientset "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/nrtupdater"
-	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/version"
-
-	"github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils"
 	e2enodes "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/nodes"
 	e2enodetopology "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/nodetopology"
 	e2epods "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/pods"
@@ -118,25 +110,6 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 			gomega.Expect(finalNodeTopo.Annotations).ToNot(gomega.BeNil(), "missing annotations entirely")
 			reason := finalNodeTopo.Annotations[nrtupdater.AnnotationRTEUpdate]
 			gomega.Expect(reason).To(gomega.Equal(nrtupdater.RTEUpdateReactive), "update reason error: expected %q got %q", nrtupdater.RTEUpdateReactive, reason)
-		})
-	})
-
-	ginkgo.Context("with the binary available", func() {
-		ginkgo.It("it should show the correct version", func() {
-			cmdline := []string{
-				filepath.Join(utils.BinariesPath, "resource-topology-exporter"),
-				"--version",
-			}
-			fmt.Fprintf(ginkgo.GinkgoWriter, "running: %v\n", cmdline)
-
-			cmd := exec.Command(cmdline[0], cmdline[1:]...)
-			cmd.Stderr = ginkgo.GinkgoWriter
-			out, err := cmd.Output()
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-			text := strings.TrimSpace(strings.Trim(string(out), version.ProgramName))
-			_, err = goversion.NewVersion(text)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		})
 	})
 })

--- a/test/e2e/rte_local/rte_local.go
+++ b/test/e2e/rte_local/rte_local.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ * resource-topology-exporter specific tests, which require access
+ * to the RTE binary and not to the cluster
+ */
+
+package rte_local
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	goversion "github.com/hashicorp/go-version"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/version"
+
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils"
+)
+
+var _ = ginkgo.Describe("[RTE][Local] Resource topology exporter", func() {
+	ginkgo.Context("with the binary available", func() {
+		ginkgo.It("it should show the correct version", func() {
+			cmdline := []string{
+				filepath.Join(utils.BinariesPath, "resource-topology-exporter"),
+				"--version",
+			}
+			fmt.Fprintf(ginkgo.GinkgoWriter, "running: %v\n", cmdline)
+
+			cmd := exec.Command(cmdline[0], cmdline[1:]...)
+			cmd.Stderr = ginkgo.GinkgoWriter
+			out, err := cmd.Output()
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			text := strings.TrimSpace(strings.Trim(string(out), version.ProgramName))
+			_, err = goversion.NewVersion(text)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
The E2E testsuite has some tests which require access
to local resources (and not to the cluster), most notably
the rte binary itself.
It's good to have such tests and we should keep them.
But we should also split them from the RTE tests proper -
which run against a cluster, to make the integration
and the consumption of the e2e suite easier.

Signed-off-by: Francesco Romani <fromani@redhat.com>