### PR TITLE
Provide topology manager policy via env variable

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,6 +16,7 @@ jobs:
     env:
       # TODO
       RTE_CONTAINER_IMAGE: quay.io/k8stopologyawarewg/resource-topology-exporter:ci
+      E2E_TOPOLOGY_MANAGER_POLICY: single-numa-node
     steps:
     - name: checkout sources
       uses: actions/checkout@v2

--- a/test/e2e/utils/nodetopology/nodetopology.go
+++ b/test/e2e/utils/nodetopology/nodetopology.go
@@ -27,7 +27,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -45,16 +44,14 @@ func GetNodeTopology(topologyClient *topologyclientset.Clientset, nodeName, name
 	return nodeTopology
 }
 
-func IsValidNodeTopology(nodeTopology *v1alpha1.NodeResourceTopology, kubeletConfig *kubeletconfig.KubeletConfiguration) bool {
+func IsValidNodeTopology(nodeTopology *v1alpha1.NodeResourceTopology, tmPolicy string) bool {
 	if nodeTopology == nil || len(nodeTopology.TopologyPolicies) == 0 {
 		framework.Logf("failed to get topology policy from the node topology resource")
 		return false
 	}
 
-	if kubeletConfig != nil {
-		if nodeTopology.TopologyPolicies[0] != (*kubeletConfig).TopologyManagerPolicy {
-			return false
-		}
+	if nodeTopology.TopologyPolicies[0] != tmPolicy {
+		return false
 	}
 
 	if nodeTopology.Zones == nil || len(nodeTopology.Zones) == 0 {

--- a/test/e2e/utils/testenv/testenv.go
+++ b/test/e2e/utils/testenv/testenv.go
@@ -22,20 +22,23 @@ import (
 
 const (
 	// we rely on kind for our CI
-	DefaultNodeName  = "kind-worker"
-	DefaultNamespace = "default"
-	RTELabelName     = "resource-topology"
-	RTEContainerName = "resource-topology-exporter-container"
+	DefaultNodeName             = "kind-worker"
+	DefaultNamespace            = "default"
+	DefaultTopologyMangerPolicy = "none"
+	RTELabelName                = "resource-topology"
+	RTEContainerName            = "resource-topology-exporter-container"
 )
 
 var (
-	currentNodeName  string
-	currentNamespace string
+	currentNodeName       string
+	currentNamespace      string
+	currentTopologyPolicy string
 )
 
 func init() {
 	currentNodeName = DefaultNodeName
 	currentNamespace = DefaultNamespace
+	currentTopologyPolicy = DefaultTopologyMangerPolicy
 }
 
 func GetNodeName() string {
@@ -50,6 +53,13 @@ func GetNamespaceName() string {
 		return nsName
 	}
 	return currentNamespace
+}
+
+func GetTopologyManagerPolicy() string {
+	if tmPolicy, ok := os.LookupEnv("E2E_TOPOLOGY_MANAGER_POLICY"); ok {
+		return tmPolicy
+	}
+	return currentTopologyPolicy
 }
 
 func SetNodeName(nodeName string) {


### PR DESCRIPTION
Since the e2e test might be running inside a pod that doesn't contain kubectl binary, we'll provide tm policy via env variable instead

Signed-off-by: Talor Itzhak <titzhak@redhat.com>