### PR TITLE
Assign test pods using node selectors

### DIFF
--- a/test/e2e/topology_updater/topology_updater.go
+++ b/test/e2e/topology_updater/topology_updater.go
@@ -70,6 +70,13 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 			topologyUpdaterNode = &workerNodes[0]
 			gomega.Expect(topologyUpdaterNode).NotTo(gomega.BeNil())
 
+			// during the e2e tests we expect changes on the node topology.
+			// but in an environment with multiple worker nodes, we might be looking at the wrong node.
+			// thus, we assign a unique label to the picked worker node
+			// and making sure to deploy the pod on it during the test using nodeSelector
+			err = e2enodes.LabelNode(f, topologyUpdaterNode, map[string]string{e2enodes.TestNodeLabel: ""})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			tmPolicy = e2etestenv.GetTopologyManagerPolicy()
 
 			initialized = true

--- a/test/e2e/utils/nodes/nodes.go
+++ b/test/e2e/utils/nodes/nodes.go
@@ -19,6 +19,8 @@ package nodes
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -40,7 +42,15 @@ const (
 	LabelRole = "node-role.kubernetes.io"
 	// LabelHostname contains the key for the hostname label
 	LabelHostname = "kubernetes.io/hostname"
+
+	TestNodeLabel = "rte-e2e-test-node"
 )
+
+type patchMapStringStringValue struct {
+	Op    string            `json:"op"`
+	Path  string            `json:"path"`
+	Value map[string]string `json:"value"`
+}
 
 // GetWorkerNodes returns all nodes labeled as worker
 func GetWorkerNodes(f *framework.Framework) ([]v1.Node, error) {
@@ -87,4 +97,30 @@ func FilterNodesWithEnoughCores(nodes []v1.Node, cpuAmount string) ([]v1.Node, e
 	}
 
 	return resNodes, nil
+}
+
+// LabelNode will add new set of labels to a given node
+func LabelNode(f *framework.Framework, node *v1.Node, newLabels map[string]string) error {
+	labelsMap := make(map[string]string)
+	labelsMap = node.Labels
+
+	for k, v := range newLabels {
+		labelsMap[k] = v
+	}
+
+	patchPayload := []patchMapStringStringValue{{
+		Op:    "replace",
+		Path:  "/metadata/labels",
+		Value: labelsMap,
+	}}
+	payloadBytes, err := json.Marshal(patchPayload)
+	if err != nil {
+		return err
+	}
+
+	_, err = f.ClientSet.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.JSONPatchType, payloadBytes, metav1.PatchOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/test/e2e/utils/pods/pods.go
+++ b/test/e2e/utils/pods/pods.go
@@ -37,6 +37,7 @@ func MakeGuaranteedSleeperPod(cpuLimit string) *v1.Pod {
 			Name: "sleeper-gu-pod",
 		},
 		Spec: v1.PodSpec{
+			NodeSelector:  map[string]string{"rte-e2e-test-node": ""},
 			RestartPolicy: v1.RestartPolicyNever,
 			Containers: []v1.Container{
 				{
@@ -64,6 +65,7 @@ func MakeBestEffortSleeperPod() *v1.Pod {
 			Name: "sleeper-be-pod",
 		},
 		Spec: v1.PodSpec{
+			NodeSelector:  map[string]string{"rte-e2e-test-node": ""},
 			RestartPolicy: v1.RestartPolicyNever,
 			Containers: []v1.Container{
 				{


### PR DESCRIPTION
During the e2e we deploy guaranteed pods that request some amount of resources and expecting to see the changes under the NRT object.
The problem is that on a cluster with multiple worker nodes, we don't know on which node the pod will land, and therefore we don't know which NRT object will change.

In order to solve the problem, we'll label an arbitrary worker node, with a unique label, at the beginning of the tests and use that label as a NodeSelector for all the pods.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>