### PR TITLE
sysinfo: fix hugepages information

### DIFF
--- a/pkg/sysinfo/hugepages_test.go
+++ b/pkg/sysinfo/hugepages_test.go
@@ -82,10 +82,10 @@ func TestHugepagesForNode(t *testing.T) {
 	if len(hpCounters["hugepages-2Mi"]) != 2 {
 		t.Errorf("found unexpected 2Mi hugepages: %v", hpCounters["hugepages-2Mi"])
 	}
-	if hpCounters["hugepages-2Mi"][0] != 6 {
+	if hpCounters["hugepages-2Mi"][0] != 12582912 {
 		t.Errorf("found unexpected 2Mi hugepages for node 0: %v", hpCounters["hugepages-2Mi"][0])
 	}
-	if hpCounters["hugepages-2Mi"][1] != 8 {
+	if hpCounters["hugepages-2Mi"][1] != 16777216 {
 		t.Errorf("found unexpected 2Mi hugepages for node 1: %v", hpCounters["hugepages-2Mi"][1])
 	}
 

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -60,7 +60,7 @@ func GetMemoryResourceCounters(hnd Handle) (map[string]PerNUMACounters, error) {
 			numaDevs = make(PerNUMACounters)
 		}
 
-		numaDevs[hpage.NodeID] = int64(hpage.Total)
+		numaDevs[hpage.NodeID] = int64(hpage.Total * hpage.SizeKB * 1024)
 		numaCounters[resourceName] = numaDevs
 	}
 


### PR DESCRIPTION
The pod resource API returns hugepages amount in bytes, so
we should calculate the total amount of hugepages also in bytes.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>