### PR TITLE
Fix E2E test for metrics

### DIFF
--- a/test/e2e/rte/metrics.go
+++ b/test/e2e/rte/metrics.go
@@ -51,7 +51,7 @@ var _ = ginkgo.Describe("[RTE] metrics", func() {
 			sel := metav1.LabelSelector{
 				MatchLabels: map[string]string{"name": e2etestenv.RTELabelName},
 			}
-			pods, err = f.ClientSet.CoreV1().Pods(e2etestenv.DefaultNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: sel.String()})
+			pods, err = f.ClientSet.CoreV1().Pods(e2etestenv.GetNamespaceName()).List(context.TODO(), metav1.ListOptions{LabelSelector: sel.String()})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			gomega.Expect(len(pods.Items)).To(gomega.Equal(1))

--- a/test/e2e/rte/metrics.go
+++ b/test/e2e/rte/metrics.go
@@ -23,6 +23,7 @@ package rte
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/labels"
 	"strconv"
 
 	"github.com/onsi/ginkgo"
@@ -48,9 +49,9 @@ var _ = ginkgo.Describe("[RTE] metrics", func() {
 		if !initialized {
 			var err error
 			var pods *corev1.PodList
-			sel := metav1.LabelSelector{
-				MatchLabels: map[string]string{"name": e2etestenv.RTELabelName},
-			}
+			sel, err := labels.Parse(fmt.Sprintf("name=%s", e2etestenv.RTELabelName))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			pods, err = f.ClientSet.CoreV1().Pods(e2etestenv.GetNamespaceName()).List(context.TODO(), metav1.ListOptions{LabelSelector: sel.String()})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 


### PR DESCRIPTION
1. Get the correct Namespace for the test
2. Fix selector creation
With the previous implementation we ended up with the error shown here:
openshift-kni/resource-topology-exporter#28 (comment)
This patch fix that
Signed-off-by: Talor Itzhak <titzhak@redhat.com>