### PR TITLE
Fix additional E2E tests errors

### DIFF
--- a/test/e2e/rte/metrics.go
+++ b/test/e2e/rte/metrics.go
@@ -55,8 +55,8 @@ var _ = ginkgo.Describe("[RTE] metrics", func() {
 			pods, err = f.ClientSet.CoreV1().Pods(e2etestenv.GetNamespaceName()).List(context.TODO(), metav1.ListOptions{LabelSelector: sel.String()})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			gomega.Expect(len(pods.Items)).To(gomega.Equal(1))
-			rtePod := &pods.Items[0]
+			gomega.Expect(len(pods.Items)).NotTo(gomega.BeZero())
+			rtePod = &pods.Items[0]
 			metricsPort, err = findMetricsPort(rtePod)
 			gomega.Expect(err).To(gomega.HaveOccurred())
 

--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -66,7 +66,7 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 
 			// pick any worker node. The (implicit, TODO: make explicit) assumption is
 			// the daemonset runs on CI on all the worker nodes.
-			topologyUpdaterNode := &workerNodes[0]
+			topologyUpdaterNode = &workerNodes[0]
 			gomega.Expect(topologyUpdaterNode).NotTo(gomega.BeNil())
 
 			initialized = true


### PR DESCRIPTION
- Fix nil dereference pointer errors
- Do not check for a single RTE pod in the cluster

Signed-off-by: Talor Itzhak <titzhak@redhat.com>