### PR TITLE
Add metrics test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -70,7 +70,7 @@ jobs:
     - name: run E2E tests
       run: |
         export KUBECONFIG=${HOME}/.kube/config 
-        _out/rte-e2e.test -ginkgo.focus='\[(RTE|TopologyUpdater)\].*\[(Local|InfraConsuming)\]'
+        _out/rte-e2e.test -ginkgo.focus='\[(RTE|TopologyUpdater)\].*\[(Local|InfraConsuming|Monitoring)\]'
 
   e2e-ip:
     runs-on: ubuntu-20.04
@@ -114,5 +114,5 @@ jobs:
 
     - name: run E2E tests
       run: |
-        export KUBECONFIG=${HOME}/.kube/config 
+        export KUBECONFIG=${HOME}/.kube/config
         _out/rte-e2e.test -ginkgo.focus='\[(RTE|TopologyUpdater)\].*\[InfraProviding\]'

--- a/test/e2e/rte/metrics.go
+++ b/test/e2e/rte/metrics.go
@@ -36,7 +36,7 @@ import (
 	e2etestenv "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/testenv"
 )
 
-var _ = ginkgo.Describe("[RTE] metrics", func() {
+var _ = ginkgo.Describe("[RTE][Monitoring]", func() {
 	var (
 		initialized bool
 		rtePod      *corev1.Pod
@@ -78,7 +78,7 @@ var _ = ginkgo.Describe("[RTE] metrics", func() {
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "ExecWithOptions failed with %s:\n%s", err, stderr)
 			gomega.Expect(stdout).To(gomega.ContainSubstring("operation_delay"))
-			gomega.Expect(stdout).To(gomega.ContainSubstring("podresource_api_call_failures_total"))
+			gomega.Expect(stdout).To(gomega.ContainSubstring("wakeup_delay"))
 		})
 	})
 })

--- a/test/e2e/rte/metrics.go
+++ b/test/e2e/rte/metrics.go
@@ -58,7 +58,7 @@ var _ = ginkgo.Describe("[RTE][Monitoring]", func() {
 			gomega.Expect(len(pods.Items)).NotTo(gomega.BeZero())
 			rtePod = &pods.Items[0]
 			metricsPort, err = findMetricsPort(rtePod)
-			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			initialized = true
 		}


### PR DESCRIPTION
The e2e which runs under gh actions never tested the metrics tests.
This exposed us to a lot of errors and tests failures under the kni-org/RTE repo which consumes those tests and is based on the fact that they're reliable.