### PR TITLE
Makefile: simplify and fix the detection of tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ IMAGETAG ?= latest
 RTE_CONTAINER_IMAGE ?= quay.io/$(REPOOWNER)/$(IMAGENAME):$(IMAGETAG)
 
 LDFLAGS = -ldflags "-s -w"
-VERSION := $(shell git tag --sort=committerdate | head -n 1)
+VERSION := $(shell git describe --tags)
 ifneq ($(VERSION),)
 LDFLAGS = -ldflags "-s -w -X github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/version.version=$(VERSION)"
 endif


### PR DESCRIPTION
Previously, the sorting was incorrectly always reporting
the first (oldest) tag to be set in the version.

Signed-off-by: Francesco Romani <fromani@redhat.com>