### PR TITLE
e2e: remove hardcoded timeouts

### DIFF
--- a/test/e2e/rte/conditions.go
+++ b/test/e2e/rte/conditions.go
@@ -3,8 +3,9 @@ package rte
 import (
 	"context"
 	"fmt"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -42,6 +43,10 @@ var _ = ginkgo.Describe("[RTE][Monitoring] conditions", func() {
 
 			timeout, err = time.ParseDuration(e2etestenv.GetPollInterval())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			// wait interval exactly multiple of the poll interval makes the test racier and less robust, so
+			// add a little skew. We pick 1 second randomly, but the idea is that small (2, 3, 5) multipliers
+			// should again not cause a total multiple of the poll interval.
+			timeout += 1 * time.Second
 
 			extClient, err = e2eclient.NewK8sExtFromFramework(f)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -41,11 +41,13 @@ import (
 	e2enodetopology "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/nodetopology"
 	e2epods "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/pods"
 	e2etestconsts "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/testconsts"
+	e2etestenv "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/testenv"
 )
 
 var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func() {
 	var (
 		initialized         bool
+		timeout             time.Duration
 		topologyClient      *topologyclientset.Clientset
 		topologyUpdaterNode *v1.Node
 		workerNodes         []v1.Node
@@ -57,6 +59,13 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 		var err error
 
 		if !initialized {
+			timeout, err = time.ParseDuration(e2etestenv.GetPollInterval())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			// wait interval exactly multiple of the poll interval makes the test racier and less robust, so
+			// add a little skew. We pick 1 second randomly, but the idea is that small (2, 3, 5) multipliers
+			// should again not cause a total multiple of the poll interval.
+			timeout += 1 * time.Second
+
 			topologyClient, err = topologyclientset.NewForConfig(f.ClientConfig())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 


### PR DESCRIPTION
We should wait relatively to the poll interval.
Removing hardcoded settings make the test more robust and
easier to adapt, and easier to consume for external projects.

Signed-off-by: Francesco Romani <fromani@redhat.com>