### PR TITLE
test: e2e: avoid hardcoded value, introspect pod

### DIFF
--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -38,6 +38,7 @@ import (
 	e2enodes "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/nodes"
 	e2enodetopology "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/nodetopology"
 	e2epods "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/pods"
+	e2ertepod "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/pods/rtepod"
 	e2etestconsts "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/testconsts"
 	e2etestenv "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/testenv"
 )
@@ -152,7 +153,14 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 				<-stopChan
 				rtePod, err := e2epods.GetPodOnNode(f, topologyUpdaterNode.Name, e2etestenv.GetNamespaceName(), e2etestenv.RTELabelName)
 				framework.ExpectNoError(err)
-				execCommandInContainer(f, rtePod.Namespace, rtePod.Name, rtePod.Spec.Containers[0].Name, "/bin/touch", "/host-run/rte/notify")
+
+				rteContainerName, err := e2ertepod.FindRTEContainerName(rtePod)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				rteNotifyFilePath, err := e2ertepod.FindNotificationFilePath(rtePod)
+
+				execCommandInContainer(f, rtePod.Namespace, rtePod.Name, rteContainerName, "/bin/touch", rteNotifyFilePath)
 				doneChan <- struct{}{}
 			}()
 

--- a/test/e2e/utils/pods/rtepod/rtepod.go
+++ b/test/e2e/utils/pods/rtepod/rtepod.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// rtepod includes utilities to introspect the RTE pod - and the RTE pod only
+package rtepod
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	rteExecutable = "resource-topology-exporter"
+
+	notificationFileOption = "--notify-file"
+)
+
+func FindMetricsPort(rtePod *corev1.Pod) (int, error) {
+	for idx := 0; idx < len(rtePod.Spec.Containers); idx++ {
+		cnt := rtePod.Spec.Containers[idx] // shortcut
+		if !isRTEContainer(cnt) {
+			continue
+		}
+
+		for _, envVar := range cnt.Env {
+			if envVar.Name == "METRICS_PORT" {
+				val, err := strconv.Atoi(envVar.Value)
+				if err != nil {
+					return 0, err
+				}
+				return val, nil
+			}
+		}
+	}
+	return 0, fmt.Errorf("cannot find METRICS_PORT environment variable")
+}
+
+func FindRTEContainerName(rtePod *corev1.Pod) (string, error) {
+	for idx := 0; idx < len(rtePod.Spec.Containers); idx++ {
+		cnt := rtePod.Spec.Containers[idx] // shortcut
+		if isRTEContainer(cnt) {
+			return cnt.Name, nil
+		}
+	}
+	return "", fmt.Errorf("no container uses %q as command or argument", rteExecutable)
+}
+
+func FindNotificationFilePath(rtePod *corev1.Pod) (string, error) {
+	for idx := 0; idx < len(rtePod.Spec.Containers); idx++ {
+		cnt := rtePod.Spec.Containers[idx] // shortcut
+		if len(cnt.Command) > 0 && strings.Contains(cnt.Command[0], rteExecutable) {
+			for _, arg := range cnt.Command {
+				if strings.Contains(arg, notificationFileOption) {
+					return extractOptionValue(arg)
+				}
+			}
+		}
+		if len(cnt.Args) > 0 && strings.Contains(cnt.Args[0], rteExecutable) {
+			for _, arg := range cnt.Args {
+				if strings.Contains(arg, notificationFileOption) {
+					return extractOptionValue(arg)
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("no container uses %q as command or argument option", notificationFileOption)
+}
+
+func isRTEContainer(cnt corev1.Container) bool {
+	// is the command name the one we expect?
+	if len(cnt.Command) > 0 && strings.Contains(cnt.Command[0], rteExecutable) {
+		return true
+	}
+	if len(cnt.Args) > 0 && strings.Contains(cnt.Args[0], rteExecutable) {
+		return true
+	}
+	return false
+}
+
+func extractOptionValue(keyValue string) (string, error) {
+	items := strings.SplitN(keyValue, "=", 2)
+	if len(items) != 2 {
+		return "", fmt.Errorf("malformed key=value option: %q", keyValue)
+	}
+	return items[1], nil
+}


### PR DESCRIPTION
We use hardcoded value in the tests mostly (= 95% of the cases)
just because it's the simplest way. A more robust and flexible
way is to introspect the actual pod and extract the values
we care about. After all, there often is a set of correct values,
and we care more about state matching expectations (with again
a set of correct values, not a single one) rather than a exact check.

Signed-off-by: Francesco Romani <fromani@redhat.com>