### PR TITLE
e2e: small fixes to tests

### DIFF
--- a/test/e2e/topology_updater/topology_updater.go
+++ b/test/e2e/topology_updater/topology_updater.go
@@ -199,7 +199,7 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 					framework.Logf("failed to get the node topology resource: %v", err)
 					return false
 				}
-				return finalNodeTopo.ObjectMeta.ResourceVersion != initialNodeTopo.ObjectMeta.ResourceVersion
+				return finalNodeTopo.ObjectMeta.Generation != initialNodeTopo.ObjectMeta.Generation
 			}, 5*timeout, 5*time.Second).Should(gomega.BeTrue(), "didn't get updated node topology info")
 			framework.Logf("final topology information: %#v", initialNodeTopo)
 


### PR DESCRIPTION
- condition tests: do not run ginkgo.Expect under Eventually because it will result
in drop us out of Eventually.
- topology updater tests: check the generation instead of resource version, because generation updated
only when was change under the non status field.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>