### PR TITLE
build: use git-semver to create the version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,18 +9,18 @@ IMAGENAME ?= resource-topology-exporter
 IMAGETAG ?= latest
 RTE_CONTAINER_IMAGE ?= quay.io/$(REPOOWNER)/$(IMAGENAME):$(IMAGETAG)
 
-LDFLAGS = -ldflags "-s -w"
-VERSION := $(shell git describe --tags)
-ifneq ($(VERSION),)
-LDFLAGS = -ldflags "-s -w -X github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/version.version=$(VERSION)"
-endif
 
 .PHONY: all
 all: build
 
+.PHONY: build-tools
+build-tools: outdir _out/git-semver
+
 .PHONY: build
-build: outdir
-	$(COMMONENVVAR) $(BUILDENVVAR) go build $(LDFLAGS) -o _out/resource-topology-exporter cmd/resource-topology-exporter/main.go
+build: build-tools
+	$(COMMONENVVAR) $(BUILDENVVAR) go build \
+	-ldflags "-s -w -X github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/version.version=$(shell _out/git-semver)" \
+	-o _out/resource-topology-exporter cmd/resource-topology-exporter/main.go
 
 .PHONY: gofmt
 gofmt:
@@ -101,3 +101,7 @@ update-manifests:
 update-golden-files:
 	@go test ./cmd/... -update
 
+# build tools:
+#
+_out/git-semver: outdir
+	@go build -o _out/git-semver vendor/github.com/mdomke/git-semver/main.go

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/go-cmp v0.5.5
 	github.com/jaypipes/ghw v0.8.1-0.20210609141030-acb1a36eaf89
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.12
+	github.com/mdomke/git-semver v1.0.0
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -449,6 +449,8 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mdomke/git-semver v1.0.0 h1:cg/a+bI/D2EtPWlx4pKSUKz9G9bTOHEBdF2EjbV0b4s=
+github.com/mdomke/git-semver v1.0.0/go.mod h1:fNw8giSaJDzhF/Gvxe7JSZJVDlkRR+/a8y1b3g6SGZ8=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989 h1:PS1dLCGtD8bb9RPKJrc8bS7qHL6JnW1CZvwzH9dPoUs=
 github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989/go.mod h1:2eu9pRWp8mo84xCg6KswZ+USQHjwgRhNp06sozOdsTY=

--- a/tools/go-semver/go-semver.go
+++ b/tools/go-semver/go-semver.go
@@ -1,0 +1,7 @@
+//+build main
+package main
+
+// A dummy go file that will be ignored for builds, but included for dependencies.
+import (
+	_ "github.com/mdomke/git-semver"
+)

--- a/vendor/github.com/mdomke/git-semver/.gitignore
+++ b/vendor/github.com/mdomke/git-semver/.gitignore
@@ -1,0 +1,14 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+/git-semver

--- a/vendor/github.com/mdomke/git-semver/LICENSE
+++ b/vendor/github.com/mdomke/git-semver/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Martin Domke
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/mdomke/git-semver/README.md
+++ b/vendor/github.com/mdomke/git-semver/README.md
@@ -1,0 +1,73 @@
+# Semantic Versioning with git tags
+
+Software should be versioned in order to be able to identify a certain
+feature set or to know when a specific bug has been fixed. It is a good
+practice to use [Sementic Versioning](https://semver.org/) (SemVer) in
+order to attach a meaning to a version number or the change thereof.
+
+[git](https://git-scm.com/) allows you to conveniently reference a certain
+state of your code through the usage of tags. Tags can have an arbitrary
+identifier, so that it seems a naturaly choice of using them for versioning.
+
+## Version tags
+
+A semantic version consists of three dot-separated parts `<major>.<minor>.<patch>`
+and this should be the name that you give to a tag. Optionally you can prepend
+the letter `v` if your language specific tooling requires it. It is also possible
+to attach a pre-release identifier to a version e.g. for a release candidate. This
+identifier is separated with hyphen from the core version component. A valid version
+tag would be, e.g. `1.2.3`, `v2.3.0`, `1.1.0-rc3`.
+
+```sh
+$ git tag v2.0.0-rc1
+```
+
+So for a tagged commit we would know which version to assign to our software, but
+which version should we use for not tagged commits? We can use `git describe` to
+get a unique identifier based on the last tagged commit.
+
+```sh
+$ git describe --tags
+3.5.1-22-gbaf822dd5
+```
+
+This is the 22nd commit after the tag `3.5.1` with the abbreviated commit hash `gbaf822dd5`.
+Sadly this identifier has two drawbacks.
+
+1. It's not compliant to SemVer, because there are multiple hyphens after the core version.
+   See the [BNF specifiction](https://github.com/semver/semver/blob/master/semver.md#backusnaur-form-grammar-for-valid-semver-versions)
+
+2. It doesn't allow proper sorting of versions, because the pre-release identifier would
+   make the version smaller than the tagged version, even though it has several commits build
+   on top of that version.
+
+## git-semver
+
+`git-semver` parses the output of `git describe` and derives a proper SemVer compliant
+version from it. E.g.:
+
+```
+3.5.1-22-gbaf822dd5 -> 3.5.2-dev22+gbaf822dd5
+4.2.0-rc3-5-fcf2c8f -> 4.2.0-rc4.dev5-fcf2c8f
+```
+
+It will attach a pre-release tag of the form `devN`, where `N` is the number of commits
+since the last commit, and the commit hash as build-metadata. Additionally the patch level
+component will be incremented in case of a pre-release-version. If the last tag itself
+contains a pre-release-identifier of the form `(alpha|beta|rc)\d+`, that identifier will
+be incremnted instead of the patch-level.
+
+If you want to add a prefix to the derived version, you can use the `-prefix`-flag like so
+
+```sh
+$ git-semver -prefix v
+v3.5.2-dev22+gbaf822dd5
+```
+
+## Installation
+
+Currently `git-semver` can be installed with `go get`
+
+```sh
+$ go get gopkg.in/mdomke/git-semver.v1
+```

--- a/vendor/github.com/mdomke/git-semver/main.go
+++ b/vendor/github.com/mdomke/git-semver/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/mdomke/git-semver/version"
+)
+
+var prefix = flag.String("prefix", "", "the version prefix (default: none)")
+
+func main() {
+	flag.Parse()
+	v, err := version.Derive()
+	if err != nil {
+		fmt.Fprint(os.Stderr, err)
+		os.Exit(1)
+	}
+	v.Prefix = *prefix
+	fmt.Println(v)
+}

--- a/vendor/github.com/mdomke/git-semver/version/version.go
+++ b/vendor/github.com/mdomke/git-semver/version/version.go
@@ -1,0 +1,157 @@
+package version
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Prefix is the valid version prefix
+const Prefix string = "v"
+
+// Version holds the parsed components of git describe
+type Version struct {
+	Prefix     string
+	Major      int
+	Minor      int
+	Patch      int
+	PreRelease string
+	Commits    int
+	Hash       string
+}
+
+func (v Version) String() string {
+	var suffix string
+	if v.Commits != 0 {
+		if v.PreRelease == "" {
+			v.Patch++
+			suffix = fmt.Sprintf("dev%d", v.Commits)
+		} else {
+			suffix = fmt.Sprintf("%s.dev%d", nextPreRelease(v.PreRelease), v.Commits)
+		}
+	} else {
+		suffix = v.PreRelease
+	}
+	if v.Hash != "" {
+		suffix += "+" + v.Hash
+	}
+	version := fmt.Sprintf("%s%d.%d.%d", v.Prefix, v.Major, v.Minor, v.Patch)
+	if suffix != "" {
+		version += "-" + suffix
+	}
+	return version
+}
+
+func nextPreRelease(r string) string {
+	re, err := regexp.Compile(`(alpha|beta|rc)(\d+)`)
+	if err != nil {
+		return r
+	}
+	match := re.FindStringSubmatch(r)
+	if match == nil {
+		return r
+	}
+	prefix := match[1]
+	var n int
+	n, err = strconv.Atoi(match[2])
+	if err != nil {
+		return r
+	}
+	n++
+	return fmt.Sprintf("%s%d", prefix, n)
+}
+
+func gitDescribe() string {
+	cmd := exec.Command("git", "describe", "--tags")
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Sprintf("0.0.0-%s-", gitCommitCount())
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func gitCommitCount() string {
+	cmd := exec.Command("git", "rev-list", "--count", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return "0"
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func parseVersion(s string, v *Version) error {
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return fmt.Errorf("git version tag must contain 3 components: X.Y.Z: Got %s", s)
+	}
+	var err error
+	v.Major, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return fmt.Errorf("Failed to parse major version: %v", err)
+	}
+	v.Minor, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return fmt.Errorf("Failed to parse minor version: %v", err)
+	}
+	v.Patch, err = strconv.Atoi(parts[2])
+	if err != nil {
+		return fmt.Errorf("Failed to parse patch version: %v", err)
+	}
+	return nil
+}
+
+func parse(s string, v *Version) (err error) {
+	var version string
+	if strings.HasPrefix(s, Prefix) {
+		v.Prefix = Prefix
+		s = strings.TrimPrefix(s, Prefix)
+	}
+	if strings.Contains(s, "-") {
+		parts := strings.Split(s, "-")
+
+		var commits string
+		switch len(parts) {
+		case 2:
+			v.PreRelease = parts[1]
+		case 3:
+			commits = parts[1]
+			v.Hash = parts[2]
+		case 4:
+			v.PreRelease = parts[1]
+			commits = parts[2]
+			v.Hash = parts[3]
+		default:
+			return fmt.Errorf("Invalid git version must be of format X.Y.Z(-<pre>)?(-n-<hash>)?: Got %s", s)
+		}
+
+		version = parts[0]
+		if commits != "" {
+			v.Commits, err = strconv.Atoi(commits)
+			if err != nil {
+				return fmt.Errorf("Failed to parse commit count from %s: %v", s, err)
+			}
+		}
+	} else {
+		version = s
+	}
+	err = parseVersion(version, v)
+	return err
+}
+
+// Derive calculates a semantic version from the output of git describe.
+// If the latest commit is not tagged, the version will have a pre-release-suffix
+// appended to it (e.g.: 1.2.3-dev3+fcf2c8f). The suffix has the format dev<n>+<hash>,
+// whereas n is the number of commits since the last tag and hash is the commit hash
+// of the latest commit. Derive will also increment the patch-level version component
+// in case it detects that the current version is a pre-release.
+// If the last tag has itself a pre-release-suffix of the form (alpha|beta|rc)\d+ and the
+// last commit is not tagged, Derive will increment the version of the pre-release
+// instead of the patch-level version.
+func Derive() (Version, error) {
+	v := Version{}
+	s := gitDescribe()
+	err := parse(s, &v)
+	return v, err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -444,6 +444,10 @@ github.com/mailru/easyjson/jlexer
 github.com/mailru/easyjson/jwriter
 # github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
 github.com/matttproud/golang_protobuf_extensions/pbutil
+# github.com/mdomke/git-semver v1.0.0
+## explicit
+github.com/mdomke/git-semver
+github.com/mdomke/git-semver/version
 # github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
 github.com/mindprince/gonvml
 # github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible


### PR DESCRIPTION
git-semver can create a proper semantic version,
while `git describe --tags` doesn't.

Signed-off-by: Francesco Romani <fromani@redhat.com>