### PR TITLE
e2e: add more test labels

### DIFF
--- a/test/e2e/rte/conditions.go
+++ b/test/e2e/rte/conditions.go
@@ -97,7 +97,7 @@ var _ = ginkgo.Describe("[RTE][Monitoring] conditions", func() {
 
 		// EventChain means that the test can be flaky in some specific cases, for example deleted CRD can be re-installed
 		// by third component
-		ginkgo.It("[EventChain] should change the RTE conditions under the pod status accordingly", func() {
+		ginkgo.It("[Disruptive][EventChain] should change the RTE conditions under the pod status accordingly", func() {
 			ginkgo.By("deleting the crd")
 
 			err := extClient.ApiextensionsV1().CustomResourceDefinitions().Delete(context.TODO(), crdName, metav1.DeleteOptions{})

--- a/test/e2e/rte/metrics.go
+++ b/test/e2e/rte/metrics.go
@@ -65,7 +65,7 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 	})
 
 	ginkgo.Context("With prometheus endpoint configured", func() {
-		ginkgo.It("should have some metrics exported", func() {
+		ginkgo.It("[EventChain] should have some metrics exported", func() {
 			rteContainerName, err := e2ertepod.FindRTEContainerName(rtePod)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 


### PR DESCRIPTION
- the conditions test tries to remove (and later restore, but still)
  the CRD, so it must be label Disruptive
- the metrics test is time-sensitive, so it must be labeled EventChain

Signed-off-by: Francesco Romani <fromani@redhat.com>