### PR TITLE
e2e: change default ns to all ns

### DIFF
--- a/test/e2e/utils/testenv/testenv.go
+++ b/test/e2e/utils/testenv/testenv.go
@@ -23,7 +23,7 @@ import (
 const (
 	// we rely on kind for our CI
 	DefaultNodeName             = "kind-worker"
-	DefaultNamespace            = "default"
+	DefaultNamespace            = ""
 	DefaultTopologyMangerPolicy = "none"
 	DefaultRTEPollInterval      = "10s"
 	RTELabelName                = "resource-topology"


### PR DESCRIPTION
There are times when we are not fully aware of the ns where the tests are running, so if we want to look for a specific pod (by label) we can look in all namespaces instead.


Signed-off-by: Talor Itzhak <titzhak@redhat.com>