### PR TITLE
cleanup concurrency model

### DIFF
--- a/pkg/notification/notification_test.go
+++ b/pkg/notification/notification_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 )
 
-func TestMakeFilter(t *testing.T) {
+func TestAnyFilter(t *testing.T) {
 	type testCase struct {
 		name     string
 		filters  []FilterEvent
@@ -36,8 +36,7 @@ func TestMakeFilter(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			f := MakeFilter(tc.filters...)
-			got := f(tc.event)
+			got := AnyFilter(tc.filters, tc.event)
 			if tc.expected != got {
 				t.Fatalf("%s event=%v expected=%t got=%t", tc.name, tc.event, tc.expected, got)
 			}

--- a/pkg/resourcetopologyexporter/resourceobserver.go
+++ b/pkg/resourcetopologyexporter/resourceobserver.go
@@ -1,0 +1,77 @@
+package resourcetopologyexporter
+
+import (
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
+
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/nrtupdater"
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podreadiness"
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/prometheus"
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcemonitor"
+)
+
+type ResourceObserver struct {
+	Infos       <-chan nrtupdater.MonitorInfo
+	resMon      resourcemonitor.ResourceMonitor
+	excludeList resourcemonitor.ResourceExcludeList
+	infoChan    chan nrtupdater.MonitorInfo
+	stopChan    chan struct{}
+}
+
+func NewResourceObserver(cli podresourcesapi.PodResourcesListerClient, args resourcemonitor.Args) (*ResourceObserver, error) {
+	resMon, err := resourcemonitor.NewResourceMonitor(cli, args)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize ResourceMonitor: %w", err)
+	}
+
+	resObs := ResourceObserver{
+		resMon:      resMon,
+		excludeList: args.ExcludeList,
+		stopChan:    make(chan struct{}),
+		infoChan:    make(chan nrtupdater.MonitorInfo),
+	}
+	resObs.Infos = resObs.infoChan
+	return &resObs, nil
+}
+
+func (rm *ResourceObserver) Stop() {
+	rm.stopChan <- struct{}{}
+}
+
+func (rm *ResourceObserver) Run(eventsChan <-chan PollTrigger, condChan chan<- v1.PodCondition) {
+	lastWakeup := time.Now()
+	for {
+		select {
+		case pt := <-eventsChan:
+			var err error
+			monInfo := nrtupdater.MonitorInfo{Timer: pt.Timer}
+
+			tsWakeupDiff := pt.Timestamp.Sub(lastWakeup)
+			lastWakeup = pt.Timestamp
+			prometheus.UpdateWakeupDelayMetric(monInfo.UpdateReason(), float64(tsWakeupDiff.Milliseconds()))
+
+			tsBegin := time.Now()
+			monInfo.Zones, err = rm.resMon.Scan(rm.excludeList)
+			tsEnd := time.Now()
+
+			condStatus := v1.ConditionTrue
+			if err != nil {
+				klog.Warningf("failed to scan pod resources: %w\n", err)
+				condStatus = v1.ConditionFalse
+				continue
+			}
+			rm.infoChan <- monInfo
+
+			tsDiff := tsEnd.Sub(tsBegin)
+			prometheus.UpdateOperationDelayMetric("podresources_scan", monInfo.UpdateReason(), float64(tsDiff.Milliseconds()))
+			podreadiness.SetCondition(condChan, podreadiness.PodresourcesFetched, condStatus)
+		case <-rm.stopChan:
+			klog.Infof("read stop at %v", time.Now())
+			return
+		}
+	}
+}

--- a/pkg/resourcetopologyexporter/resourcetopologyexporter.go
+++ b/pkg/resourcetopologyexporter/resourcetopologyexporter.go
@@ -64,11 +64,8 @@ func Execute(cli podresourcesapi.PodResourcesListerClient, nrtupdaterArgs nrtupd
 	eventsChan := make(chan PollTrigger)
 	infoChannel, _ := resObs.Run(eventsChan, condChan)
 
-	upd, err := nrtupdater.NewNRTUpdater(nrtupdaterArgs, string(tmPolicy))
-	if err != nil {
-		return fmt.Errorf("failed to initialize NRT updater: %w", err)
-	}
-	upd.Run(infoChannel, condChan)
+	upd := nrtupdater.NewNRTUpdater(nrtupdaterArgs, string(tmPolicy))
+	go upd.Run(infoChannel, condChan)
 
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {


### PR DESCRIPTION
Make sure the goroutines are always handled on the calling sites; streamline all the relevant packages to expose the Run()/Stop() interface.


Resolves: #93