### PR TITLE
resourceobserver: update status with ConditionFalse

### DIFF
--- a/pkg/resourcetopologyexporter/resourceobserver.go
+++ b/pkg/resourcetopologyexporter/resourceobserver.go
@@ -63,6 +63,7 @@ func (rm *ResourceObserver) Run(eventsChan <-chan notification.Event, condChan c
 			if err != nil {
 				klog.Warningf("failed to scan pod resources: %w\n", err)
 				condStatus = v1.ConditionFalse
+				podreadiness.SetCondition(condChan, podreadiness.PodresourcesFetched, condStatus)
 				continue
 			}
 			rm.infoChan <- monInfo


### PR DESCRIPTION
When the scan returns with an error we should update the status condition to false.
Prior to this change we were hitting the continue and never updating the condition properly.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>