### PR TITLE
e2e: deflake nonintegral cpu request test

### DIFF
--- a/test/e2e/topology_updater/topology_updater.go
+++ b/test/e2e/topology_updater/topology_updater.go
@@ -154,8 +154,8 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 			if len(initialAllocRes) == 0 || len(finalAllocRes) == 0 {
 				ginkgo.Fail(fmt.Sprintf("failed to find available resources from node topology initial=%v final=%v", initialAllocRes, finalAllocRes))
 			}
-			zoneName, resName, cmp, ok := e2enodetopology.CmpAvailableResources(initialAllocRes, finalAllocRes)
-			framework.Logf("zone=%q resource=%q cmp=%v ok=%v", zoneName, resName, cmp, ok)
+			zoneName, cmp, ok := e2enodetopology.CmpAvailableCPUs(initialAllocRes, finalAllocRes)
+			framework.Logf("zone=%q resource=%q cmp=%v ok=%v", zoneName, v1.ResourceCPU, cmp, ok)
 			if !ok {
 				ginkgo.Fail(fmt.Sprintf("failed to compare available resources from node topology initial=%v final=%v", initialAllocRes, finalAllocRes))
 			}

--- a/test/e2e/utils/nodetopology/nodetopology.go
+++ b/test/e2e/utils/nodetopology/nodetopology.go
@@ -180,3 +180,27 @@ func CmpResourceList(expected, got v1.ResourceList) (string, int, bool) {
 	}
 	return "", 0, true
 }
+
+func CmpAvailableCPUs(expected, got map[string]v1.ResourceList) (string, int, bool) {
+	if len(got) != len(expected) {
+		framework.Logf("-> expected=%v (len=%d) got=%v (len=%d)", expected, len(expected), got, len(got))
+		return "", 0, false
+	}
+
+	for expZoneName, expResList := range expected {
+		gotResList, ok := got[expZoneName]
+		if !ok {
+			return expZoneName, 0, false
+		}
+		if _, ok := expResList[v1.ResourceCPU]; !ok {
+			return expZoneName, 0, false
+		}
+
+		if _, ok := gotResList[v1.ResourceCPU]; !ok {
+			return expZoneName, 0, false
+		}
+		quan := gotResList[v1.ResourceCPU]
+		return "", quan.Cmp(expResList[v1.ResourceCPU]), true
+	}
+	return "", 0, true
+}


### PR DESCRIPTION
When a guaranteed pod asks for nonintegral CPU request, we expect no changes under the amount of available resources in the NRT object.
This is not completely true and can make the test falky, because the pods gets its memory from the reserved pool (which in turn decreased from the available resources in the NRT object) and then the comparison failed, i.e. initial > final, when the test expect otherwise.

Let's change the test to compare only CPUs, which is eventually what we're mostly care about here.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>