### PR TITLE
gh actions: finalize move to go 1.17

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: set up golang
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: 1.17
 
     - name: format
       run: ./hack/check-format.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/setup-go@v2
       id: go
       with:
-        go-version: 1.16
+        go-version: 1.17
 
     - name: verify modules
       run: go mod verify


### PR DESCRIPTION
In commit 79d078198d9189bf202c19071dfdf610a40649ff we partially updated to golang 1.17, but we left some gh actions lanes behind to 1.16 for no good reason. Let's fix that.