### PR TITLE
gh actions: upgrade kind to 1.23 fully

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,8 @@ jobs:
     - name: create K8S kind cluster
       run: |
         # kind is part of 20.04 image, see: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
-        kind create cluster --config=hack/kind-config-e2e.yaml --image kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+        # see image listing in https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.1
+        kind create cluster --config=hack/kind-config-e2e.yaml --image kindest/node:v1.23.0@sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
         kind load docker-image ${{ env.RTE_CONTAINER_IMAGE }}:${{ env.RELEASE_VERSION }}
 
     - name: deploy RTE


### PR DESCRIPTION
The release flow was mistakenly left behind

Signed-off-by: Francesco Romani <fromani@redhat.com>