### PR TITLE
e2e: fix FindNotificationFilePath function

### DIFF
--- a/manifests/resource-topology-exporter-ds-kube-watch.yaml
+++ b/manifests/resource-topology-exporter-ds-kube-watch.yaml
@@ -21,11 +21,12 @@ spec:
         image: ${RTE_CONTAINER_IMAGE}
         command:
         - /bin/resource-topology-exporter
-        - --sleep-interval=${RTE_POLL_INTERVAL}
-        - --sysfs=/host-sys
-        - --kubelet-state-dir=/host-var/lib/kubelet
-        - --kubelet-config-file=/host-var/lib/kubelet/config.yaml
-        - --podresources-socket=unix:///host-var/lib/kubelet/pod-resources/kubelet.sock
+        args:
+          - --sleep-interval=${RTE_POLL_INTERVAL}
+          - --sysfs=/host-sys
+          - --kubelet-state-dir=/host-var/lib/kubelet
+          - --kubelet-config-file=/host-var/lib/kubelet/config.yaml
+          - --podresources-socket=unix:///host-var/lib/kubelet/pod-resources/kubelet.sock
         env:
         - name: NODE_NAME
           valueFrom:

--- a/manifests/resource-topology-exporter-ds-notif-file.yaml
+++ b/manifests/resource-topology-exporter-ds-notif-file.yaml
@@ -18,13 +18,14 @@ spec:
         image: ${RTE_CONTAINER_IMAGE}
         command:
         - /bin/resource-topology-exporter
-        - -v=5
-        - --sleep-interval=${RTE_POLL_INTERVAL}
-        - --sysfs=/host-sys
-        - --notify-file=/host-run/rte/notify
-        - --topology-manager-policy=single-numa-node
-        - --topology-manager-scope=container
-        - --podresources-socket=unix:///host-podresources/kubelet.sock
+        args:
+          - -v=5
+          - --sleep-interval=${RTE_POLL_INTERVAL}
+          - --sysfs=/host-sys
+          - --notify-file=/host-run/rte/notify
+          - --topology-manager-policy=single-numa-node
+          - --topology-manager-scope=container
+          - --podresources-socket=unix:///host-podresources/kubelet.sock
         env:
         - name: NODE_NAME
           valueFrom:

--- a/manifests/resource-topology-exporter.yaml
+++ b/manifests/resource-topology-exporter.yaml
@@ -69,13 +69,14 @@ spec:
         image: ${RTE_CONTAINER_IMAGE}
         command:
         - /bin/resource-topology-exporter
-        - -v=5
-        - --sleep-interval=${RTE_POLL_INTERVAL}
-        - --sysfs=/host-sys
-        - --kubelet-state-dir=/host-var/lib/kubelet
-        - --kubelet-config-file=/host-var/lib/kubelet/config.yaml
-        - --podresources-socket=unix:///host-var/lib/kubelet/pod-resources/kubelet.sock
-        - --notify-file=/host-run/rte/notify
+        args:
+          - -v=5
+          - --sleep-interval=${RTE_POLL_INTERVAL}
+          - --sysfs=/host-sys
+          - --kubelet-state-dir=/host-var/lib/kubelet
+          - --kubelet-config-file=/host-var/lib/kubelet/config.yaml
+          - --podresources-socket=unix:///host-var/lib/kubelet/pod-resources/kubelet.sock
+          - --notify-file=/host-run/rte/notify
         env:
         - name: NODE_NAME
           valueFrom:

--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -165,8 +165,8 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 				rteContainerName, err := e2ertepod.FindRTEContainerName(rtePod)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				rteNotifyFilePath, err := e2ertepod.FindNotificationFilePath(rtePod)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				execCommandInContainer(f, rtePod.Namespace, rtePod.Name, rteContainerName, "/bin/touch", rteNotifyFilePath)
 				doneChan <- struct{}{}

--- a/test/e2e/utils/pods/rtepod/rtepod.go
+++ b/test/e2e/utils/pods/rtepod/rtepod.go
@@ -65,13 +65,6 @@ func FindNotificationFilePath(rtePod *corev1.Pod) (string, error) {
 	for idx := 0; idx < len(rtePod.Spec.Containers); idx++ {
 		cnt := rtePod.Spec.Containers[idx] // shortcut
 		if len(cnt.Command) > 0 && strings.Contains(cnt.Command[0], rteExecutable) {
-			for _, arg := range cnt.Command {
-				if strings.Contains(arg, notificationFileOption) {
-					return extractOptionValue(arg)
-				}
-			}
-		}
-		if len(cnt.Args) > 0 && strings.Contains(cnt.Args[0], rteExecutable) {
 			for _, arg := range cnt.Args {
 				if strings.Contains(arg, notificationFileOption) {
 					return extractOptionValue(arg)
@@ -79,7 +72,7 @@ func FindNotificationFilePath(rtePod *corev1.Pod) (string, error) {
 			}
 		}
 	}
-	return "", fmt.Errorf("no container uses %q as command or argument option", notificationFileOption)
+	return "", fmt.Errorf("no container uses %q as an argument option", notificationFileOption)
 }
 
 func isRTEContainer(cnt corev1.Container) bool {


### PR DESCRIPTION
RTE manifest layout has changed in latest deployer version, when underthe RTE container we splitted the command and arguments of RTE container into separte fileds.
This requires the FindNotificationFilePath to be looking for the --notify-file argument in the correct place.

Furthermore, we didn't check the returned error from the function, let's fix it as well.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>