### PR TITLE
err: properly wrap errors

### DIFF
--- a/cmd/resource-topology-exporter/main.go
+++ b/cmd/resource-topology-exporter/main.go
@@ -131,7 +131,7 @@ func parseArgs(args ...string) (ProgArgs, error) {
 
 	conf, err := readConfig(configPath)
 	if err != nil {
-		return pArgs, fmt.Errorf("error getting exclude list from the configuration: %v", err)
+		return pArgs, fmt.Errorf("error getting exclude list from the configuration: %w", err)
 	}
 
 	if len(conf.ExcludeList) != 0 {

--- a/pkg/nrtupdater/nrtupdater.go
+++ b/pkg/nrtupdater/nrtupdater.go
@@ -92,7 +92,7 @@ func (te *NRTUpdater) UpdateWithClient(cli topologyclientset.Interface, info Mon
 
 		nrtCreated, err := cli.TopologyV1alpha1().NodeResourceTopologies().Create(context.TODO(), &nrtNew, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("update failed for NRT instance: %v", err)
+			return fmt.Errorf("update failed for NRT instance: %w", err)
 		}
 		klog.V(2).Infof("update created NRT instance: %v", utils.Dump(nrtCreated))
 		return nil
@@ -110,7 +110,7 @@ func (te *NRTUpdater) UpdateWithClient(cli topologyclientset.Interface, info Mon
 
 	nrtUpdated, err := cli.TopologyV1alpha1().NodeResourceTopologies().Update(context.TODO(), nrtMutated, metav1.UpdateOptions{})
 	if err != nil {
-		return fmt.Errorf("update failed for NRT instance: %v", err)
+		return fmt.Errorf("update failed for NRT instance: %w", err)
 	}
 	klog.V(5).Infof("update changed CRD instance: %v", utils.Dump(nrtUpdated))
 	return nil

--- a/pkg/podrescli/client.go
+++ b/pkg/podrescli/client.go
@@ -128,7 +128,7 @@ func NewK8SClient(socketPath string) (podresourcesapi.PodResourcesListerClient, 
 func NewFilteringClient(socketPath string, debug bool, referenceContainer *ContainerIdent) (podresourcesapi.PodResourcesListerClient, error) {
 	cli, err := NewK8SClient(socketPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create podresource client: %v", err)
+		return nil, fmt.Errorf("failed to create podresource client: %w", err)
 	}
 	klog.V(4).Infof("connected to %q", socketPath)
 	return NewFilteringClientFromLister(cli, debug, referenceContainer)

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -75,7 +75,7 @@ func InitPrometheus() error {
 
 	if envValue, ok := os.LookupEnv("METRICS_PORT"); ok {
 		if _, err = strconv.Atoi(envValue); err != nil {
-			return fmt.Errorf("the env variable PROMETHEUS_PORT has inccorrect value %q; err %v", envValue, err)
+			return fmt.Errorf("the env variable PROMETHEUS_PORT has inccorrect value %q: %w", envValue, err)
 		}
 		port = envValue
 	}


### PR DESCRIPTION
In few places we still use the old-way to construct errors.
Let's make another step towards go 1.13+ error handling.
See https://go.dev/blog/go1.13-errors

Signed-off-by: Francesco Romani <fromani@redhat.com>