### PR TITLE
pkg: repurpose `utils`

### DIFF
--- a/pkg/dump/dump.go
+++ b/pkg/dump/dump.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package dump
 
 import (
 	"fmt"
@@ -22,8 +22,8 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// Dump dumps an object into YAML textual format
-func Dump(obj interface{}) string {
+// Object dumps an object into YAML textual format
+func Object(obj interface{}) string {
 	out, err := yaml.Marshal(obj)
 	if err != nil {
 		return fmt.Sprintf("<!!! FAILED TO MARSHAL %T (%v) !!!>\n", obj, err)

--- a/pkg/dump/dump_test.go
+++ b/pkg/dump/dump_test.go
@@ -1,4 +1,4 @@
-package utils
+package dump
 
 import (
 	"testing"
@@ -6,7 +6,7 @@ import (
 	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
 )
 
-func TestDump(t *testing.T) {
+func TestDumpObject(t *testing.T) {
 	type testCase struct {
 		name     string
 		obj      interface{}
@@ -28,9 +28,9 @@ func TestDump(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := Dump(tc.obj)
+			got := Object(tc.obj)
 			if tc.expected != got {
-				t.Fatalf("Dump(%s) error expected=%q got=%q", tc.name, tc.expected, got)
+				t.Fatalf("dump.Object(%s) error expected=%q got=%q", tc.name, tc.expected, got)
 			}
 		})
 	}

--- a/pkg/nrtupdater/nrtupdater.go
+++ b/pkg/nrtupdater/nrtupdater.go
@@ -13,11 +13,11 @@ import (
 	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
 	topologyclientset "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned"
 
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/dump"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/k8sannotations"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/k8shelpers"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podreadiness"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/prometheus"
-	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/utils"
 )
 
 const (
@@ -72,7 +72,7 @@ func (te *NRTUpdater) Update(info MonitorInfo) error {
 }
 
 func (te *NRTUpdater) UpdateWithClient(cli topologyclientset.Interface, info MonitorInfo) error {
-	klog.V(3).Infof("update: sending zone: %v", utils.Dump(info.Zones))
+	klog.V(3).Infof("update: sending zone: %v", dump.Object(info.Zones))
 
 	if te.args.NoPublish {
 		return nil
@@ -92,7 +92,7 @@ func (te *NRTUpdater) UpdateWithClient(cli topologyclientset.Interface, info Mon
 		if err != nil {
 			return fmt.Errorf("update failed for NRT instance: %w", err)
 		}
-		klog.V(2).Infof("update created NRT instance: %v", utils.Dump(nrtCreated))
+		klog.V(2).Infof("update created NRT instance: %v", dump.Object(nrtCreated))
 		return nil
 	}
 
@@ -107,7 +107,7 @@ func (te *NRTUpdater) UpdateWithClient(cli topologyclientset.Interface, info Mon
 	if err != nil {
 		return fmt.Errorf("update failed for NRT instance: %w", err)
 	}
-	klog.V(5).Infof("update changed CRD instance: %v", utils.Dump(nrtUpdated))
+	klog.V(5).Infof("update changed CRD instance: %v", dump.Object(nrtUpdated))
 	return nil
 }
 


### PR DESCRIPTION
"utils" packages in golang are a antipattern:
https://dave.cheney.net/2019/01/08/avoid-package-names-like-base-util-or-common
so let's repurpose our onw in something more meaningful.
`test/e2e/utils` will be addressed in a future PR.

Signed-off-by: Francesco Romani <fromani@redhat.com>