### PR TITLE
prometheus: add metrics about writes

### DIFF
--- a/pkg/nrtupdater/nrtupdater.go
+++ b/pkg/nrtupdater/nrtupdater.go
@@ -92,7 +92,8 @@ func (te *NRTUpdater) UpdateWithClient(cli topologyclientset.Interface, info Mon
 		if err != nil {
 			return fmt.Errorf("update failed for NRT instance: %w", err)
 		}
-		klog.V(2).Infof("update created NRT instance: %v", dump.Object(nrtCreated))
+		prometheus.UpdateNodeResourceTopologyWritesMetric("create", info.UpdateReason())
+		klog.V(2).Infof("nrtupdater created NRT instance: %v", dump.Object(nrtCreated))
 		return nil
 	}
 
@@ -107,7 +108,8 @@ func (te *NRTUpdater) UpdateWithClient(cli topologyclientset.Interface, info Mon
 	if err != nil {
 		return fmt.Errorf("update failed for NRT instance: %w", err)
 	}
-	klog.V(5).Infof("update changed CRD instance: %v", dump.Object(nrtUpdated))
+	prometheus.UpdateNodeResourceTopologyWritesMetric("update", info.UpdateReason())
+	klog.V(5).Infof("nrtupdater changed CRD instance: %v", dump.Object(nrtUpdated))
 	return nil
 }
 

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -23,6 +23,11 @@ var (
 		Help: "The total number of podresource api calls that failed by the updater",
 	}, []string{"node", "function_name"})
 
+	NodeResourceTopologyWrites = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "rte_noderesourcetopology_writes_total",
+		Help: "The total number of NodeResourceTopology writes",
+	}, []string{"node", "operation", "trigger"})
+
 	OperationDelay = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "rte_operation_delay_milliseconds",
 		Help: "The latency between exporting stages, milliseconds",
@@ -45,6 +50,14 @@ func getNodeName() (string, error) {
 		}
 	}
 	return val, nil
+}
+
+func UpdateNodeResourceTopologyWritesMetric(operation, trigger string) {
+	NodeResourceTopologyWrites.With(prometheus.Labels{
+		"node":      nodeName,
+		"operation": operation,
+		"trigger":   trigger,
+	}).Inc()
 }
 
 func UpdatePodResourceApiCallsFailureMetric(funcName string) {


### PR DESCRIPTION
Add metrics to report the traffic towards CRDs generated by the RTEs.
Even though issues like
https://github.com/kubernetes/kubernetes/issues/105932
https://github.com/kubernetes/kubernetes/issues/101755
should be solved, it's both cheap and useful to provide these metrics on RTE side, since we already have all the infrastructure
in place.

Signed-off-by: Francesco Romani <fromani@redhat.com>