### PR TITLE
tools: add tool to generate fake load

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,11 @@ all: build
 .PHONY: build-tools
 build-tools: outdir _out/git-semver
 
+.PHONY: extra-tools
+extra-tools: outdir _out/nrtstress
+
 .PHONY: build
-build: build-tools
+build: build-tools extra-tools
 	$(COMMONENVVAR) $(BUILDENVVAR) go build \
 	-ldflags "-s -w -X github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/version.version=$(shell _out/git-semver)" \
 	-o _out/resource-topology-exporter cmd/resource-topology-exporter/main.go
@@ -100,6 +103,11 @@ update-manifests:
 .PHONY: update-golden-files
 update-golden-files:
 	@go test ./cmd/... -update
+
+# helper tools
+_out/nrtstress: outdir
+	$(COMMONENVVAR) $(BUILDENVVAR) go build \
+	-o _out/nrtstress tools/nrtstress/main.go
 
 # build tools:
 #

--- a/pkg/nrtupdater/fake/fake.go
+++ b/pkg/nrtupdater/fake/fake.go
@@ -1,0 +1,104 @@
+package fake
+
+import (
+	"math/rand"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/klog/v2"
+
+	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/dump"
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/nrtupdater"
+)
+
+type Generator struct {
+	Infos    <-chan nrtupdater.MonitorInfo
+	infoChan chan nrtupdater.MonitorInfo
+	interval time.Duration
+}
+
+func NewGenerator(interval time.Duration) *Generator {
+	gen := Generator{
+		infoChan: make(chan nrtupdater.MonitorInfo),
+		interval: interval,
+	}
+	gen.Infos = gen.infoChan
+	return &gen
+}
+
+func (ge *Generator) Run() {
+	ticker := time.NewTicker(ge.interval)
+
+	for {
+		select {
+		case <-ticker.C:
+			mi := nrtupdater.MonitorInfo{
+				Timer: true,
+				Zones: Zones(),
+			}
+			ge.infoChan <- mi
+			klog.V(5).Infof("generated periodic update: %v", dump.Object(mi.Zones))
+		}
+	}
+}
+
+func Zones() v1alpha1.ZoneList {
+	zones := v1alpha1.ZoneList{
+		v1alpha1.Zone{
+			Name: "fake-node-0",
+			Type: "Node",
+			Costs: []v1alpha1.CostInfo{
+				{
+					Name:  "fake-node-0",
+					Value: 10,
+				},
+				{
+					Name:  "fake-node-1",
+					Value: 21,
+				},
+			},
+			Resources: []v1alpha1.ResourceInfo{
+				ResourceInfoCPUs(128, 126, 126),
+				ResourceInfoDevices(16),
+			},
+		},
+		v1alpha1.Zone{
+			Name: "fake-node-1",
+			Type: "Node",
+			Costs: []v1alpha1.CostInfo{
+				{
+					Name:  "fake-node-1",
+					Value: 10,
+				},
+				{
+					Name:  "fake-node-0",
+					Value: 21,
+				},
+			},
+			Resources: []v1alpha1.ResourceInfo{
+				ResourceInfoCPUs(128, 126, 126),
+				ResourceInfoDevices(16),
+			},
+		},
+	}
+	return zones
+}
+
+func ResourceInfoDevices(count int) v1alpha1.ResourceInfo {
+	return v1alpha1.ResourceInfo{
+		Name:        "vendor.com/device",
+		Capacity:    *resource.NewQuantity(16, resource.DecimalSI),
+		Allocatable: *resource.NewQuantity(16, resource.DecimalSI),
+		Available:   *resource.NewQuantity(int64(rand.Intn(17)), resource.DecimalSI),
+	}
+}
+
+func ResourceInfoCPUs(capacity, allocatable, available int) v1alpha1.ResourceInfo {
+	return v1alpha1.ResourceInfo{
+		Name:        "cpu",
+		Capacity:    *resource.NewQuantity(int64(capacity), resource.DecimalSI),
+		Allocatable: *resource.NewQuantity(int64(allocatable), resource.DecimalSI),
+		Available:   *resource.NewQuantity(int64(rand.Intn(available+1)), resource.DecimalSI),
+	}
+}


### PR DESCRIPTION
With small additions to our existing packages,
we can build a simple NRT load generator, useful to
test, troubleshoot and assess the scalability of RTE.

Note this tool is intentionally not shipped yet in releases:
still needs to mature a bit at least.

Signed-off-by: Francesco Romani <fromani@redhat.com>