### PR TITLE
Enable dynamic resource creation option

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -73,6 +73,12 @@ jobs:
         kubectl logs -l name=resource-topology -c resource-topology-exporter-container || :
         kubectl get noderesourcetopologies.topology.node.k8s.io -A -o yaml
 
+    - name: deploy sample-devices
+      run: | 
+        hack/deploy-devices.sh
+        hack/check-ds.sh default device-plugin-a-ds
+        kubectl describe nodes -l node-role.kubernetes.io/worker= || :
+
     - name: run E2E tests
       run: |
         export KUBECONFIG=${HOME}/.kube/config 

--- a/cmd/resource-topology-exporter/main.go
+++ b/cmd/resource-topology-exporter/main.go
@@ -99,6 +99,7 @@ func parseArgs(args ...string) (ProgArgs, error) {
 	flags.StringVar(&pArgs.Resourcemonitor.SysfsRoot, "sysfs", "/sys", "Top-level component path of sysfs.")
 	flags.BoolVar(&pArgs.Resourcemonitor.PodSetFingerprint, "pods-fingerprint", false, "If enable, compute and report the pod set fingerprint.")
 	flags.BoolVar(&pArgs.Resourcemonitor.ExposeTiming, "expose-timing", false, "If enable, expose expected and actual sleep interval as annotations.")
+	flags.BoolVar(&pArgs.Resourcemonitor.RefreshNodeResources, "refresh-node-resources", false, "If enable, track changes in node's resources")
 
 	flags.StringVar(&configPath, "config", "/etc/resource-topology-exporter/config.yaml", "Configuration file path. Use this to set the exclude list.")
 

--- a/cmd/resource-topology-exporter/main_test.go
+++ b/cmd/resource-topology-exporter/main_test.go
@@ -66,6 +66,7 @@ func (s *ArgsParseTestSuite) TestArgsParse() {
 			So(err, ShouldBeNil)
 			So(pArgs.NRTupdater.Oneshot, ShouldBeTrue)
 			So(pArgs.NRTupdater.NoPublish, ShouldBeTrue)
+			So(pArgs.Resourcemonitor.RefreshNodeResources, ShouldBeFalse)
 		})
 
 		Convey("must parse custom flags properly", func() {

--- a/hack/deploy-devices.sh
+++ b/hack/deploy-devices.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+DIRNAME="$(dirname "$(readlink -f "$0")")"
+
+kubectl create -f ${DIRNAME}/../manifests/sample-devices/test-devicepluginA-config.yaml
+kubectl create -f ${DIRNAME}/../manifests/sample-devices/test-devicepluginA-ds.yaml

--- a/manifests/resource-topology-exporter-rbac.yaml
+++ b/manifests/resource-topology-exporter-rbac.yaml
@@ -18,6 +18,9 @@ rules:
 - apiGroups: [""]
   resources: ["pods/status"]
   verbs: ["update"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/manifests/resource-topology-exporter.yaml
+++ b/manifests/resource-topology-exporter.yaml
@@ -18,6 +18,9 @@ rules:
 - apiGroups: [""]
   resources: ["pods/status"]
   verbs: ["update"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -79,6 +82,7 @@ spec:
           - --notify-file=/host-run/rte/notify
           - --pods-fingerprint
           - --expose-timing
+          - --refresh-node-resources
         env:
         - name: NODE_NAME
           valueFrom:

--- a/manifests/sample-devices/test-devicepluginA-config.yaml
+++ b/manifests/sample-devices/test-devicepluginA-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: device-a-configmap
+data:
+  example_com_deviceA.yaml: |
+    devicename: tty1
+    devices:
+      '*':
+        - id: DevA1
+          healthy: true
+          numanode: 0
+        - id: DevA2
+          healthy: false
+          numanode: 0

--- a/manifests/sample-devices/test-devicepluginA-ds.yaml
+++ b/manifests/sample-devices/test-devicepluginA-ds.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: device-plugin-a-ds
+spec:
+  selector:
+    matchLabels:
+      name: device-plugin-a
+  template:
+    metadata:
+      labels:
+        name: device-plugin-a
+    spec:
+      hostNetwork: true
+      containers:
+        - name: device-plugin-a-container
+          image: quay.io/k8stopologyawareschedwg/sample-device-plugin:v0.1.1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DEVICE_RESOURCE_NAME
+              value: "example.com/deviceA"
+          volumeMounts:
+            - name: kubeletsockets
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: device-a-config-vol
+              mountPath: /etc/devices
+      volumes:
+        - name: kubeletsockets
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - configMap:
+            name: device-a-configmap
+          name: device-a-config-vol

--- a/test/e2e/utils/nodetopology/nodetopology.go
+++ b/test/e2e/utils/nodetopology/nodetopology.go
@@ -107,8 +107,7 @@ func IsValidResourceList(zoneName string, resources v1alpha1.ResourceInfoList) b
 	}
 	foundCpu := false
 	for _, resource := range resources {
-		// TODO constant not in the APIs
-		if strings.ToUpper(resource.Name) == "CPU" {
+		if resource.Name == string(v1.ResourceCPU) {
 			foundCpu = true
 		}
 		available := resource.Available.Value()
@@ -200,10 +199,12 @@ func CmpAvailableCPUs(expected, got map[string]v1.ResourceList) (string, int, bo
 			return expZoneName, 0, false
 		}
 		if _, ok := expResList[v1.ResourceCPU]; !ok {
+			framework.Logf("resource=%q does not exist in expected list; expected=%v", v1.ResourceCPU, expResList)
 			return expZoneName, 0, false
 		}
 
 		if _, ok := gotResList[v1.ResourceCPU]; !ok {
+			framework.Logf("resource=%q does not exist in got list; got=%v", v1.ResourceCPU, gotResList)
 			return expZoneName, 0, false
 		}
 		quan := gotResList[v1.ResourceCPU]

--- a/test/e2e/utils/testenv/testenv.go
+++ b/test/e2e/utils/testenv/testenv.go
@@ -28,6 +28,7 @@ const (
 	DefaultRTEPollInterval      = "10s"
 	RTELabelName                = "resource-topology"
 	RTEContainerName            = "resource-topology-exporter-container"
+	DefaultDeviceName           = "example.com/deviceA"
 )
 
 var (
@@ -70,6 +71,13 @@ func GetPollInterval() string {
 		return DefaultRTEPollInterval
 	}
 	return pollInterval
+}
+
+func GetDeviceName() string {
+	if devName, ok := os.LookupEnv("E2E_DEVICE_NAME"); ok {
+		return devName
+	}
+	return DefaultDeviceName
 }
 
 func SetNodeName(nodeName string) {


### PR DESCRIPTION
Creating new resources (usually devices) doesn't reflect under the NRT object.
The logic to support was already there, but the option to enable it was never exposed to the user. 

For the start, this option would be disabled by default until we'll be sure it's stable enough 

- [x] expose the flag
- [x] fix capacity
- [x] unit-test
- [x] e2e test
- [x] decide whether we want to enable this option by default
- [x] consider decoupling this logic from the standard polling routine.