### PR TITLE
[release-0.7] e2e: ghactions: run only a subset of tests on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
     - name: run E2E tests
       run: |
         export KUBECONFIG=${HOME}/.kube/config 
-        _out/rte-e2e.test -ginkgo.focus='\[(RTE|TopologyUpdater)\].*\[(Local|InfraConsuming|Monitoring)\]'
+        _out/rte-e2e.test -ginkgo.focus='\[release\]'
 
     - name: compute signature
       run: |

--- a/test/e2e/rte/conditions.go
+++ b/test/e2e/rte/conditions.go
@@ -83,7 +83,7 @@ var _ = ginkgo.Describe("[RTE][Monitoring] conditions", func() {
 	}
 
 	ginkgo.Context("with NRT objects created", func() {
-		ginkgo.It("should have custom RTE conditions under the pod status", func() {
+		ginkgo.It("[release] should have custom RTE conditions under the pod status", func() {
 			gomega.Eventually(func() bool {
 				return waitForPodCondition(e2etestenv.RTELabelName, podreadiness.PodresourcesFetched, v1.ConditionTrue)
 				// wait for twice the poll interval, so the conditions will have enough time to get updated

--- a/test/e2e/rte/metrics.go
+++ b/test/e2e/rte/metrics.go
@@ -96,7 +96,7 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 			gomega.Expect(stdout).To(gomega.ContainSubstring("wakeup_delay"))
 		})
 
-		ginkgo.It("it should report noderesourcetopology writes", func() {
+		ginkgo.It("[release] it should report noderesourcetopology writes", func() {
 			nodes, err := e2enodes.FilterNodesWithEnoughCores(workerNodes, "1000m")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			if len(nodes) < 1 {

--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -248,7 +248,7 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 			gomega.Expect(pfpStable).To(gomega.BeTrue(), "PFP changed unexpectedly")
 		})
 
-		ginkgo.It("[PodFingerprint] it should report updated value if the set of running pods changes", func() {
+		ginkgo.It("[release][PodFingerprint] it should report updated value if the set of running pods changes", func() {
 			nodes, err := e2enodes.FilterNodesWithEnoughCores(workerNodes, "1000m")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			if len(nodes) < 1 {

--- a/test/e2e/rte_local/rte_local.go
+++ b/test/e2e/rte_local/rte_local.go
@@ -38,7 +38,7 @@ import (
 
 var _ = ginkgo.Describe("[RTE][Local] Resource topology exporter", func() {
 	ginkgo.Context("with the binary available", func() {
-		ginkgo.It("it should show the correct version", func() {
+		ginkgo.It("[release] it should show the correct version", func() {
 			cmdline := []string{
 				filepath.Join(utils.BinariesPath, "resource-topology-exporter"),
 				"--version",

--- a/test/e2e/topology_updater/topology_updater.go
+++ b/test/e2e/topology_updater/topology_updater.go
@@ -89,7 +89,7 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 		}
 	})
 
-	ginkgo.Context("with cluster configured", func() {
+	ginkgo.Context("[release] with cluster configured", func() {
 		ginkgo.It("it should not account for any cpus if a container doesn't request exclusive cpus (best effort QOS)", func() {
 			ginkgo.By("getting the initial topology information")
 			initialNodeTopo := e2enodetopology.GetNodeTopology(topologyClient, topologyUpdaterNode.Name)


### PR DESCRIPTION
To make the releases more predictable, until we fix all the flakes,
run a selected subset of most critical e2e tests on the release
flow, and ONLY on the release flow.
On PRs, we will keep running the full suite.

Signed-off-by: Francesco Romani <fromani@redhat.com>