### PR TITLE
e2e: gh actions: handle missing devices

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,8 @@ jobs:
 
     - name: run E2E tests
       run: |
-        export KUBECONFIG=${HOME}/.kube/config 
+        export KUBECONFIG=${HOME}/.kube/config
+        export E2E_DEVICE_NAME=
         _out/rte-e2e.test -ginkgo.focus='\[release\]'
 
     - name: compute signature

--- a/test/e2e/utils/nodetopology/nodetopology.go
+++ b/test/e2e/utils/nodetopology/nodetopology.go
@@ -31,17 +31,7 @@ import (
 )
 
 func GetNodeTopology(topologyClient *topologyclientset.Clientset, nodeName string) *v1alpha1.NodeResourceTopology {
-	var nodeTopology *v1alpha1.NodeResourceTopology
-	var err error
-	gomega.EventuallyWithOffset(1, func() bool {
-		nodeTopology, err = topologyClient.TopologyV1alpha1().NodeResourceTopologies().Get(context.TODO(), nodeName, metav1.GetOptions{})
-		if err != nil {
-			framework.Logf("failed to get the node topology resource: %v", err)
-			return false
-		}
-		return true
-	}, time.Minute, 5*time.Second).Should(gomega.BeTrue())
-	return nodeTopology
+	return GetNodeTopologyWithResource(topologyClient, nodeName, "")
 }
 
 func GetNodeTopologyWithResource(topologyClient *topologyclientset.Clientset, nodeName, resName string) *v1alpha1.NodeResourceTopology {
@@ -52,6 +42,9 @@ func GetNodeTopologyWithResource(topologyClient *topologyclientset.Clientset, no
 		if err != nil {
 			framework.Logf("failed to get the node topology resource: %v", err)
 			return false
+		}
+		if resName == "" {
+			return true
 		}
 		return containsResource(nodeTopology, resName)
 	}, time.Minute, 5*time.Second).Should(gomega.BeTrue())


### PR DESCRIPTION
the release lane wants to run a well-defined subset of e2e tests, and in this flow we don't want to use devices with the sample-device-plugin.

So let's make sure we tolerate this flow without false negatives.

Signed-off-by: Francesco Romani <fromani@redhat.com>