### PR TITLE
test: e2e: rename imports

### DIFF
--- a/test/e2e/rte/conditions.go
+++ b/test/e2e/rte/conditions.go
@@ -10,8 +10,8 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 
-	v1 "k8s.io/api/core/v1"
-	v1apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -31,7 +31,7 @@ var _ = ginkgo.Describe("[RTE][Monitoring] conditions", func() {
 		namespace   string
 		extClient   *clientset.Clientset
 		timeout     time.Duration
-		crd         *v1apiextensions.CustomResourceDefinition
+		crd         *apiextv1.CustomResourceDefinition
 	)
 
 	f := framework.NewDefaultFramework("conditions")
@@ -71,7 +71,7 @@ var _ = ginkgo.Describe("[RTE][Monitoring] conditions", func() {
 		}
 	})
 
-	waitForPodCondition := func(podName string, conditionType podreadiness.RTEConditionType, expectedConditionStatus v1.ConditionStatus) bool {
+	waitForPodCondition := func(podName string, conditionType podreadiness.RTEConditionType, expectedConditionStatus corev1.ConditionStatus) bool {
 		pods, err := e2epods.GetPodsByLabel(f, namespace, fmt.Sprintf("name=%s", podName))
 		if err != nil {
 			return false
@@ -87,12 +87,12 @@ var _ = ginkgo.Describe("[RTE][Monitoring] conditions", func() {
 	ginkgo.Context("with NRT objects created", func() {
 		ginkgo.It("[release] should have custom RTE conditions under the pod status", func() {
 			gomega.Eventually(func() bool {
-				return waitForPodCondition(e2etestenv.RTELabelName, podreadiness.PodresourcesFetched, v1.ConditionTrue)
+				return waitForPodCondition(e2etestenv.RTELabelName, podreadiness.PodresourcesFetched, corev1.ConditionTrue)
 				// wait for twice the poll interval, so the conditions will have enough time to get updated
 			}, 2*timeout, 1*time.Second).Should(gomega.BeTrue(), "pod contains wrong condition value")
 
 			gomega.Eventually(func() bool {
-				return waitForPodCondition(e2etestenv.RTELabelName, podreadiness.NodeTopologyUpdated, v1.ConditionTrue)
+				return waitForPodCondition(e2etestenv.RTELabelName, podreadiness.NodeTopologyUpdated, corev1.ConditionTrue)
 				// wait for twice the poll interval, so the conditions will have enough time to get updated
 			}, 2*timeout, 1*time.Second).Should(gomega.BeTrue(), "pod contains wrong condition value")
 		})
@@ -106,7 +106,7 @@ var _ = ginkgo.Describe("[RTE][Monitoring] conditions", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			gomega.Eventually(func() bool {
-				return waitForPodCondition(e2etestenv.RTELabelName, podreadiness.NodeTopologyUpdated, v1.ConditionFalse)
+				return waitForPodCondition(e2etestenv.RTELabelName, podreadiness.NodeTopologyUpdated, corev1.ConditionFalse)
 				// wait for twice the poll interval, so the conditions will have enough time to get updated
 			}, 2*timeout, 1*time.Second).Should(gomega.BeTrue(), "pod contains wrong condition value")
 
@@ -116,15 +116,15 @@ var _ = ginkgo.Describe("[RTE][Monitoring] conditions", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			gomega.Eventually(func() bool {
-				return waitForPodCondition(e2etestenv.RTELabelName, podreadiness.NodeTopologyUpdated, v1.ConditionFalse)
+				return waitForPodCondition(e2etestenv.RTELabelName, podreadiness.NodeTopologyUpdated, corev1.ConditionFalse)
 			}, 2*timeout, 1*time.Second).Should(gomega.BeTrue(), "pod contains wrong condition value")
 		})
 	})
 })
 
-func cmpConditionsByTypeAndStatus(podConds []v1.PodCondition, conditionType podreadiness.RTEConditionType, status v1.ConditionStatus) bool {
+func cmpConditionsByTypeAndStatus(podConds []corev1.PodCondition, conditionType podreadiness.RTEConditionType, status corev1.ConditionStatus) bool {
 	for _, cond := range podConds {
-		if cond.Type == v1.PodConditionType(conditionType) && cond.Status == status {
+		if cond.Type == corev1.PodConditionType(conditionType) && cond.Status == status {
 			return true
 		}
 	}

--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -28,7 +28,7 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -58,8 +58,8 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 		initialized         bool
 		timeout             time.Duration
 		topologyClient      *topologyclientset.Clientset
-		topologyUpdaterNode *v1.Node
-		workerNodes         []v1.Node
+		topologyUpdaterNode *corev1.Node
+		workerNodes         []corev1.Node
 	)
 
 	f := framework.NewDefaultFramework("rte")
@@ -119,7 +119,7 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 				defer ginkgo.GinkgoRecover()
 
 				<-stopChan
-				podMap := make(map[string]*v1.Pod)
+				podMap := make(map[string]*corev1.Pod)
 				pod := f.PodClient().CreateSync(sleeperPod)
 				podMap[pod.Name] = pod
 				e2epods.DeletePodsAsync(f, podMap)

--- a/test/e2e/topology_updater/topology_updater.go
+++ b/test/e2e/topology_updater/topology_updater.go
@@ -29,7 +29,7 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -49,8 +49,8 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 		timeout             time.Duration
 		tmPolicy            string
 		topologyClient      *topologyclientset.Clientset
-		topologyUpdaterNode *v1.Node
-		workerNodes         []v1.Node
+		topologyUpdaterNode *corev1.Node
+		workerNodes         []corev1.Node
 	)
 
 	f := framework.NewDefaultFramework("topology-updater")
@@ -100,7 +100,7 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 			ginkgo.By("creating a pod consuming resources from the shared, non-exclusive CPU pool (best-effort QoS)")
 			sleeperPod := e2epods.MakeBestEffortSleeperPod()
 
-			podMap := make(map[string]*v1.Pod)
+			podMap := make(map[string]*corev1.Pod)
 			pod := f.PodClient().CreateSync(sleeperPod)
 			podMap[pod.Name] = pod
 			defer e2epods.DeletePodsAsync(f, podMap)
@@ -141,7 +141,7 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 			sleeperPod := e2epods.MakeGuaranteedSleeperPod("500m")
 			defer e2epods.Cooldown(f)
 
-			podMap := make(map[string]*v1.Pod)
+			podMap := make(map[string]*corev1.Pod)
 			pod := f.PodClient().CreateSync(sleeperPod)
 			podMap[pod.Name] = pod
 			defer e2epods.DeletePodsAsync(f, podMap)
@@ -159,7 +159,7 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 				ginkgo.Fail(fmt.Sprintf("failed to find available resources from node topology initial=%v final=%v", initialAllocRes, finalAllocRes))
 			}
 			zoneName, cmp, ok := e2enodetopology.CmpAvailableCPUs(initialAllocRes, finalAllocRes)
-			framework.Logf("zone=%q resource=%q cmp=%v ok=%v", zoneName, v1.ResourceCPU, cmp, ok)
+			framework.Logf("zone=%q resource=%q cmp=%v ok=%v", zoneName, corev1.ResourceCPU, cmp, ok)
 			if !ok {
 				ginkgo.Fail(fmt.Sprintf("failed to compare available resources from node topology initial=%v final=%v", initialAllocRes, finalAllocRes))
 			}
@@ -190,7 +190,7 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 			sleeperPod := e2epods.MakeGuaranteedSleeperPod("1000m")
 			defer e2epods.Cooldown(f)
 
-			podMap := make(map[string]*v1.Pod)
+			podMap := make(map[string]*corev1.Pod)
 			pod := f.PodClient().CreateSync(sleeperPod)
 			podMap[pod.Name] = pod
 			defer e2epods.DeletePodsAsync(f, podMap)

--- a/test/e2e/utils/nodes/nodes.go
+++ b/test/e2e/utils/nodes/nodes.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -50,12 +50,12 @@ type patchMapStringStringValue struct {
 }
 
 // GetWorkerNodes returns all nodes labeled as worker
-func GetWorkerNodes(f *framework.Framework) ([]v1.Node, error) {
+func GetWorkerNodes(f *framework.Framework) ([]corev1.Node, error) {
 	return GetNodesByRole(f, RoleWorker)
 }
 
 // GetByRole returns all nodes with the specified role
-func GetNodesByRole(f *framework.Framework, role string) ([]v1.Node, error) {
+func GetNodesByRole(f *framework.Framework, role string) ([]corev1.Node, error) {
 	selector, err := labels.Parse(fmt.Sprintf("%s/%s=", LabelRole, role))
 	if err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ func GetNodesByRole(f *framework.Framework, role string) ([]v1.Node, error) {
 }
 
 // GetBySelector returns all nodes with the specified selector
-func GetNodesBySelector(f *framework.Framework, selector labels.Selector) ([]v1.Node, error) {
+func GetNodesBySelector(f *framework.Framework, selector labels.Selector) ([]corev1.Node, error) {
 	nodes, err := f.ClientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
 	if err != nil {
 		return nil, err
@@ -73,13 +73,13 @@ func GetNodesBySelector(f *framework.Framework, selector labels.Selector) ([]v1.
 }
 
 // FilterNodesWithEnoughCores returns all nodes with at least the amount of given CPU allocatable
-func FilterNodesWithEnoughCores(nodes []v1.Node, cpuAmount string) ([]v1.Node, error) {
+func FilterNodesWithEnoughCores(nodes []corev1.Node, cpuAmount string) ([]corev1.Node, error) {
 	requestCpu := resource.MustParse(cpuAmount)
 	framework.Logf("checking request %v on %d nodes", requestCpu, len(nodes))
 
-	resNodes := []v1.Node{}
+	resNodes := []corev1.Node{}
 	for _, node := range nodes {
-		availCpu, ok := node.Status.Allocatable[v1.ResourceCPU]
+		availCpu, ok := node.Status.Allocatable[corev1.ResourceCPU]
 		if !ok || availCpu.IsZero() {
 			return nil, fmt.Errorf("node %q has no allocatable CPU", node.Name)
 		}
@@ -97,7 +97,7 @@ func FilterNodesWithEnoughCores(nodes []v1.Node, cpuAmount string) ([]v1.Node, e
 }
 
 // LabelNode will add new set of labels to a given node
-func LabelNode(f *framework.Framework, node *v1.Node, newLabels map[string]string) error {
+func LabelNode(f *framework.Framework, node *corev1.Node, newLabels map[string]string) error {
 	labelsMap := make(map[string]string)
 	labelsMap = node.Labels
 

--- a/test/e2e/utils/nodetopology/nodetopology.go
+++ b/test/e2e/utils/nodetopology/nodetopology.go
@@ -25,7 +25,7 @@ import (
 	topologyclientset "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned"
 	"github.com/onsi/gomega"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
@@ -114,7 +114,7 @@ func IsValidResourceList(zoneName string, resources v1alpha1.ResourceInfoList) b
 	}
 	foundCpu := false
 	for _, resource := range resources {
-		if resource.Name == string(v1.ResourceCPU) {
+		if resource.Name == string(corev1.ResourceCPU) {
 			foundCpu = true
 		}
 		available := resource.Available.Value()
@@ -128,15 +128,15 @@ func IsValidResourceList(zoneName string, resources v1alpha1.ResourceInfoList) b
 	return foundCpu
 }
 
-func AvailableResourceListFromNodeResourceTopology(nodeTopo *v1alpha1.NodeResourceTopology) map[string]v1.ResourceList {
-	availRes := make(map[string]v1.ResourceList)
+func AvailableResourceListFromNodeResourceTopology(nodeTopo *v1alpha1.NodeResourceTopology) map[string]corev1.ResourceList {
+	availRes := make(map[string]corev1.ResourceList)
 	for _, zone := range nodeTopo.Zones {
 		if zone.Type != "Node" {
 			continue
 		}
-		resList := make(v1.ResourceList)
+		resList := make(corev1.ResourceList)
 		for _, res := range zone.Resources {
-			resList[v1.ResourceName(res.Name)] = res.Available
+			resList[corev1.ResourceName(res.Name)] = res.Available
 		}
 		if len(resList) == 0 {
 			continue
@@ -146,7 +146,7 @@ func AvailableResourceListFromNodeResourceTopology(nodeTopo *v1alpha1.NodeResour
 	return availRes
 }
 
-func LessAvailableResources(expected, got map[string]v1.ResourceList) (string, string, bool) {
+func LessAvailableResources(expected, got map[string]corev1.ResourceList) (string, string, bool) {
 	zoneName, resName, cmp, ok := CmpAvailableResources(expected, got)
 	if !ok {
 		framework.Logf("-> cmp failed (not ok)")
@@ -159,7 +159,7 @@ func LessAvailableResources(expected, got map[string]v1.ResourceList) (string, s
 	return "", "", false
 }
 
-func CmpAvailableResources(expected, got map[string]v1.ResourceList) (string, string, int, bool) {
+func CmpAvailableResources(expected, got map[string]corev1.ResourceList) (string, string, int, bool) {
 	if len(got) != len(expected) {
 		framework.Logf("-> expected=%v (len=%d) got=%v (len=%d)", expected, len(expected), got, len(got))
 		return "", "", 0, false
@@ -176,7 +176,7 @@ func CmpAvailableResources(expected, got map[string]v1.ResourceList) (string, st
 	return "", "", 0, true
 }
 
-func CmpResourceList(expected, got v1.ResourceList) (string, int, bool) {
+func CmpResourceList(expected, got corev1.ResourceList) (string, int, bool) {
 	if len(got) != len(expected) {
 		framework.Logf("-> expected=%v (len=%d) got=%v (len=%d)", expected, len(expected), got, len(got))
 		return "", 0, false
@@ -194,7 +194,7 @@ func CmpResourceList(expected, got v1.ResourceList) (string, int, bool) {
 	return "", 0, true
 }
 
-func CmpAvailableCPUs(expected, got map[string]v1.ResourceList) (string, int, bool) {
+func CmpAvailableCPUs(expected, got map[string]corev1.ResourceList) (string, int, bool) {
 	if len(got) != len(expected) {
 		framework.Logf("-> expected=%v (len=%d) got=%v (len=%d)", expected, len(expected), got, len(got))
 		return "", 0, false
@@ -205,17 +205,17 @@ func CmpAvailableCPUs(expected, got map[string]v1.ResourceList) (string, int, bo
 		if !ok {
 			return expZoneName, 0, false
 		}
-		if _, ok := expResList[v1.ResourceCPU]; !ok {
-			framework.Logf("resource=%q does not exist in expected list; expected=%v", v1.ResourceCPU, expResList)
+		if _, ok := expResList[corev1.ResourceCPU]; !ok {
+			framework.Logf("resource=%q does not exist in expected list; expected=%v", corev1.ResourceCPU, expResList)
 			return expZoneName, 0, false
 		}
 
-		if _, ok := gotResList[v1.ResourceCPU]; !ok {
-			framework.Logf("resource=%q does not exist in got list; got=%v", v1.ResourceCPU, gotResList)
+		if _, ok := gotResList[corev1.ResourceCPU]; !ok {
+			framework.Logf("resource=%q does not exist in got list; got=%v", corev1.ResourceCPU, gotResList)
 			return expZoneName, 0, false
 		}
-		quan := gotResList[v1.ResourceCPU]
-		return "", quan.Cmp(expResList[v1.ResourceCPU]), true
+		quan := gotResList[corev1.ResourceCPU]
+		return "", quan.Cmp(expResList[corev1.ResourceCPU]), true
 	}
 	return "", 0, true
 }

--- a/test/e2e/utils/pods/pods.go
+++ b/test/e2e/utils/pods/pods.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -42,26 +42,26 @@ const (
 	RTELabelName = "resource-topology"
 )
 
-func MakeGuaranteedSleeperPod(cpuLimit string) *v1.Pod {
-	return &v1.Pod{
+func MakeGuaranteedSleeperPod(cpuLimit string) *corev1.Pod {
+	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "sleeper-gu-pod",
 		},
-		Spec: v1.PodSpec{
+		Spec: corev1.PodSpec{
 			NodeSelector:  map[string]string{e2etestconsts.TestNodeLabel: ""},
-			RestartPolicy: v1.RestartPolicyNever,
-			Containers: []v1.Container{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
 				{
 					Name:  "sleeper-gu-cnt",
 					Image: CentosImage,
 					// 1 hour (or >= 1h in general) is "forever" for our purposes
 					Command: []string{"/bin/sleep", "1h"},
-					Resources: v1.ResourceRequirements{
-						Limits: v1.ResourceList{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
 							// we use 1 core because that's the minimal meaningful quantity
-							v1.ResourceName(v1.ResourceCPU): resource.MustParse(cpuLimit),
+							corev1.ResourceName(corev1.ResourceCPU): resource.MustParse(cpuLimit),
 							// any random reasonable amount is fine
-							v1.ResourceName(v1.ResourceMemory): resource.MustParse("100Mi"),
+							corev1.ResourceName(corev1.ResourceMemory): resource.MustParse("100Mi"),
 						},
 					},
 				},
@@ -70,15 +70,15 @@ func MakeGuaranteedSleeperPod(cpuLimit string) *v1.Pod {
 	}
 }
 
-func MakeBestEffortSleeperPod() *v1.Pod {
-	return &v1.Pod{
+func MakeBestEffortSleeperPod() *corev1.Pod {
+	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "sleeper-be-pod",
 		},
-		Spec: v1.PodSpec{
+		Spec: corev1.PodSpec{
 			NodeSelector:  map[string]string{e2etestconsts.TestNodeLabel: ""},
-			RestartPolicy: v1.RestartPolicyNever,
-			Containers: []v1.Container{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
 				{
 					Name:  "sleeper-be-cnt",
 					Image: CentosImage,
@@ -90,7 +90,7 @@ func MakeBestEffortSleeperPod() *v1.Pod {
 	}
 }
 
-func DeletePodsAsync(f *framework.Framework, podMap map[string]*v1.Pod) {
+func DeletePodsAsync(f *framework.Framework, podMap map[string]*corev1.Pod) {
 	var wg sync.WaitGroup
 	for _, pod := range podMap {
 		wg.Add(1)
@@ -128,7 +128,7 @@ func Cooldown(f *framework.Framework) {
 	time.Sleep(sleepTime + 500*time.Millisecond)
 }
 
-func GetPodsByLabel(f *framework.Framework, ns, label string) ([]v1.Pod, error) {
+func GetPodsByLabel(f *framework.Framework, ns, label string) ([]corev1.Pod, error) {
 	sel, err := labels.Parse(label)
 	if err != nil {
 		return nil, err
@@ -141,7 +141,7 @@ func GetPodsByLabel(f *framework.Framework, ns, label string) ([]v1.Pod, error) 
 	return pods.Items, nil
 }
 
-func GetPodOnNode(f *framework.Framework, nodeName, namespace, labelName string) (*v1.Pod, error) {
+func GetPodOnNode(f *framework.Framework, nodeName, namespace, labelName string) (*corev1.Pod, error) {
 	framework.Logf("searching for RTE pod in namespace %q with label %q", namespace, labelName)
 	pods, err := GetPodsByLabel(f, namespace, fmt.Sprintf("name=%s", labelName))
 	if err != nil {


### PR DESCRIPTION
rename k8s import for clarity, standardization and less ambiguity. No intended changes in behavior.

Signed-off-by: Francesco Romani <fromani@redhat.com>