### PR TITLE
golang: update toolchain to 1.19.3

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/setup-go@v2
       id: go
       with:
-        go-version: 1.18.1
+        go-version: 1.19.3
 
     - name: show tool versions
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     - name: set up golang
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.1
+        go-version: 1.19.3
 
     - name: format
       run: ./hack/check-format.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/setup-go@v2
       id: go
       with:
-        go-version: 1.18.1
+        go-version: 1.19.3
 
     - name: verify modules
       run: go mod verify

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k8stopologyawareschedwg/resource-topology-exporter
 
-go 1.18
+go 1.19
 
 require (
 	github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492

--- a/pkg/ratelimiter/ratelimiter.go
+++ b/pkg/ratelimiter/ratelimiter.go
@@ -2,7 +2,9 @@
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +21,7 @@ import (
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/notification"
 )
 
-//Size of the buffered channel used to handle events
+// Size of the buffered channel used to handle events
 // TODO: Should it be an input parameter?
 const bufferSize uint16 = 5
 
@@ -100,10 +102,10 @@ func (rles *RateLimitedEventSource) run() {
 }
 
 // receiver read from the input channel and move the event to bufferCh as fast as possible
-//so it could be available to read again an so minimize the amount of time the
-//decorated EventSource is blocked trying to write a new event in the "input" channel.
+// so it could be available to read again an so minimize the amount of time the
+// decorated EventSource is blocked trying to write a new event in the "input" channel.
 // Also the write in bufferCh is done so if it is full the operation silently "fails"
-//instead of block
+// instead of block
 func (rles *RateLimitedEventSource) receiver() {
 	for {
 		select {

--- a/pkg/ratelimiter/ratelimiter_test.go
+++ b/pkg/ratelimiter/ratelimiter_test.go
@@ -2,7 +2,9 @@
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/resourcemonitor/resourcemonitor.go
+++ b/pkg/resourcemonitor/resourcemonitor.go
@@ -85,7 +85,7 @@ func (rel ResourceExcludeList) String() string {
 // mapping resource -> count
 type resourceCounter map[v1.ResourceName]int64
 
-//mapping numa cell -> resource counter
+// mapping numa cell -> resource counter
 type perNUMAResourceCounter map[int]resourceCounter
 
 type resourceMonitor struct {


### PR DESCRIPTION
1.19.3 is the most recent release at time of writing.

Signed-off-by: Francesco Romani <fromani@redhat.com>