### PR TITLE
notification: allow to disable the polling

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -95,7 +95,7 @@ func LoadArgs(args ...string) (ProgArgs, error) {
 	flags.BoolVar(&pArgs.RTE.Debug, "debug", false, " Enable debug output.")
 	flags.StringVar(&pArgs.RTE.TopologyManagerPolicy, "topology-manager-policy", DefaultTopologyManagerPolicy(), "Explicitly set the topology manager policy instead of reading from the kubelet.")
 	flags.StringVar(&pArgs.RTE.TopologyManagerScope, "topology-manager-scope", DefaultTopologyManagerScope(), "Explicitly set the topology manager scope instead of reading from the kubelet.")
-	flags.DurationVar(&pArgs.RTE.SleepInterval, "sleep-interval", 60*time.Second, "Time to sleep between podresources API polls.")
+	flags.DurationVar(&pArgs.RTE.SleepInterval, "sleep-interval", 60*time.Second, "Time to sleep between podresources API polls. Set to zero to completely disable the polling.")
 	flags.StringVar(&pArgs.RTE.KubeletConfigFile, "kubelet-config-file", "/podresources/config.yaml", "Kubelet config file path.")
 	flags.StringVar(&pArgs.RTE.PodResourcesSocketPath, "podresources-socket", "unix:///podresources/kubelet.sock", "Pod Resource Socket path to use.")
 	flags.BoolVar(&pArgs.RTE.PodReadinessEnable, "podreadiness", true, "Custom condition injection using Podreadiness.")

--- a/pkg/resourcetopologyexporter/resourcetopologyexporter.go
+++ b/pkg/resourcetopologyexporter/resourcetopologyexporter.go
@@ -75,7 +75,12 @@ func Execute(cli podresourcesapi.PodResourcesListerClient, nrtupdaterArgs nrtupd
 func createEventSource(rteArgs *Args) (notification.EventSource, error) {
 	var es notification.EventSource
 
-	eventSource, err := notification.NewUnlimitedEventSource(rteArgs.SleepInterval)
+	eventSource, err := notification.NewUnlimitedEventSource()
+	if err != nil {
+		return nil, err
+	}
+
+	err = eventSource.SetInterval(rteArgs.SleepInterval)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Up until now, it was not possible to disable the polling. The workaround was to set the polling interval to a insanely high value (like 1 day) but still, this is not a real fix.

The assumption was some form of polling was always useful, but over time this turns out to be not really true, and disabling polling is helpful at very least in testing.

Implying some form of polling was more than a historical combination of events than a conscious design decision, so let's fix it, better late than never.

Signed-off-by: Francesco Romani <fromani@redhat.com>