### PR TITLE
e2e: deflake e2e pfp tests

### DIFF
--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -109,7 +109,6 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 			initialNodeTopo := e2enodetopology.GetNodeTopology(topologyClient, topologyUpdaterNode.Name)
 			ginkgo.By("creating a pod consuming the shared pool")
 			sleeperPod := e2epods.MakeGuaranteedSleeperPod("1000m")
-			defer e2epods.Cooldown(f)
 
 			stopChan := make(chan struct{})
 			doneChan := make(chan struct{})

--- a/test/e2e/topology_updater/topology_updater.go
+++ b/test/e2e/topology_updater/topology_updater.go
@@ -31,6 +31,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
 
@@ -100,10 +101,10 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 			ginkgo.By("creating a pod consuming resources from the shared, non-exclusive CPU pool (best-effort QoS)")
 			sleeperPod := e2epods.MakeBestEffortSleeperPod()
 
-			podMap := make(map[string]*corev1.Pod)
 			pod := f.PodClient().CreateSync(sleeperPod)
-			podMap[pod.Name] = pod
-			defer e2epods.DeletePodsAsync(f, podMap)
+			ginkgo.DeferCleanup(func(cs clientset.Interface, podNamespace, podName string) error {
+				return e2epods.DeletePodSyncByName(cs, podNamespace, podName)
+			}, f.ClientSet, pod.Namespace, pod.Name)
 
 			cooldown := 3 * timeout
 			ginkgo.By(fmt.Sprintf("getting the updated topology - sleeping for %v", cooldown))
@@ -141,10 +142,10 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 			sleeperPod := e2epods.MakeGuaranteedSleeperPod("500m")
 			defer e2epods.Cooldown(f)
 
-			podMap := make(map[string]*corev1.Pod)
 			pod := f.PodClient().CreateSync(sleeperPod)
-			podMap[pod.Name] = pod
-			defer e2epods.DeletePodsAsync(f, podMap)
+			ginkgo.DeferCleanup(func(cs clientset.Interface, podNamespace, podName string) error {
+				return e2epods.DeletePodSyncByName(cs, podNamespace, podName)
+			}, f.ClientSet, pod.Namespace, pod.Name)
 
 			cooldown := 3 * timeout
 			ginkgo.By(fmt.Sprintf("getting the updated topology - sleeping for %v", cooldown))
@@ -190,10 +191,10 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 			sleeperPod := e2epods.MakeGuaranteedSleeperPod("1000m")
 			defer e2epods.Cooldown(f)
 
-			podMap := make(map[string]*corev1.Pod)
 			pod := f.PodClient().CreateSync(sleeperPod)
-			podMap[pod.Name] = pod
-			defer e2epods.DeletePodsAsync(f, podMap)
+			ginkgo.DeferCleanup(func(cs clientset.Interface, podNamespace, podName string) error {
+				return e2epods.DeletePodSyncByName(cs, podNamespace, podName)
+			}, f.ClientSet, pod.Namespace, pod.Name)
 
 			ginkgo.By("getting the updated topology")
 			var finalNodeTopo *v1alpha1.NodeResourceTopology

--- a/test/e2e/topology_updater/topology_updater.go
+++ b/test/e2e/topology_updater/topology_updater.go
@@ -140,7 +140,6 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 			initialNodeTopo := e2enodetopology.GetNodeTopology(topologyClient, topologyUpdaterNode.Name)
 			ginkgo.By("creating a pod consuming resources from the shared, non-exclusive CPU pool (guaranteed QoS, nonintegral request)")
 			sleeperPod := e2epods.MakeGuaranteedSleeperPod("500m")
-			defer e2epods.Cooldown(f)
 
 			pod := f.PodClient().CreateSync(sleeperPod)
 			ginkgo.DeferCleanup(func(cs clientset.Interface, podNamespace, podName string) error {
@@ -189,7 +188,6 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 
 			ginkgo.By("creating a pod consuming exclusive CPUs")
 			sleeperPod := e2epods.MakeGuaranteedSleeperPod("1000m")
-			defer e2epods.Cooldown(f)
 
 			pod := f.PodClient().CreateSync(sleeperPod)
 			ginkgo.DeferCleanup(func(cs clientset.Interface, podNamespace, podName string) error {

--- a/test/e2e/utils/pods/pods.go
+++ b/test/e2e/utils/pods/pods.go
@@ -19,7 +19,6 @@ package pods
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -118,22 +117,6 @@ func DeletePodSyncByName(cs clientset.Interface, podNamespace, podName string) e
 		framework.Failf("Failed to delete pod %q: %v", podName, err)
 	}
 	return e2epod.WaitForPodToDisappear(cs, podNamespace, podName, labels.Everything(), 2*time.Second, framework.DefaultPodDeletionTimeout)
-}
-
-func Cooldown(f *framework.Framework) {
-	pollInterval, ok := os.LookupEnv("RTE_POLL_INTERVAL")
-	if !ok {
-		// nothing to do!
-		return
-	}
-	sleepTime, err := time.ParseDuration(pollInterval)
-	if err != nil {
-		framework.Logf("WaitPodToBeGone: cannot parse %q: %v", pollInterval, err)
-		return
-	}
-
-	// wait a little more than a full poll interval to make sure the resourcemonitor catches up
-	time.Sleep(sleepTime + 500*time.Millisecond)
 }
 
 func GetPodsByLabel(f *framework.Framework, ns, label string) ([]corev1.Pod, error) {

--- a/test/e2e/utils/pods/pods.go
+++ b/test/e2e/utils/pods/pods.go
@@ -25,14 +25,17 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/apimachinery/pkg/labels"
-
 	"github.com/onsi/ginkgo/v2"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 
 	e2etestconsts "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/testconsts"
 )
@@ -90,26 +93,31 @@ func MakeBestEffortSleeperPod() *corev1.Pod {
 	}
 }
 
-func DeletePodsAsync(f *framework.Framework, podMap map[string]*corev1.Pod) {
+func DeletePodsAsync(f *framework.Framework, podList ...types.NamespacedName) {
 	var wg sync.WaitGroup
-	for _, pod := range podMap {
+	for _, pod := range podList {
 		wg.Add(1)
 		go func(podNS, podName string) {
 			defer ginkgo.GinkgoRecover()
 			defer wg.Done()
 
-			DeletePodSyncByName(f, podName)
+			DeletePodSyncByName(f.ClientSet, podNS, podName)
 		}(pod.Namespace, pod.Name)
 	}
 	wg.Wait()
 }
 
-func DeletePodSyncByName(f *framework.Framework, podName string) {
+func DeletePodSyncByName(cs clientset.Interface, podNamespace, podName string) error {
 	gp := int64(0)
 	delOpts := metav1.DeleteOptions{
 		GracePeriodSeconds: &gp,
 	}
-	f.PodClient().DeleteSync(podName, delOpts, framework.DefaultPodDeletionTimeout)
+	framework.Logf("Deleting pod %s/%s cs=%v", podNamespace, podName, cs)
+	err := cs.CoreV1().Pods(podNamespace).Delete(context.TODO(), podName, delOpts)
+	if err != nil && !apierrors.IsNotFound(err) {
+		framework.Failf("Failed to delete pod %q: %v", podName, err)
+	}
+	return e2epod.WaitForPodToDisappear(cs, podNamespace, podName, labels.Everything(), 2*time.Second, framework.DefaultPodDeletionTimeout)
 }
 
 func Cooldown(f *framework.Framework) {


### PR DESCRIPTION
we have longstanding PFP flakes. The root cause is we asyncronously delete test pods, so the pod state leaks from a test to another.
This is because we delete test pod asynchronously in defer(), which leads to leak
A more robust approach is to synchronously delete pods inside ginkgo v2 `DeferCleanup`.
As extra bonus, we can now get rid of the `Cooldown` hack.

Found while testing/tuning #153 