### PR TITLE
Add labels to container image: version and commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ clean:
 .PHONY: image
 image: outdir build
 	@echo "building image"
-	$(RUNTIME) build -f images/Dockerfile -t $(RTE_CONTAINER_IMAGE) .
+	$(RUNTIME) build -f images/Dockerfile -t $(RTE_CONTAINER_IMAGE) --build-arg VERSION=$(shell _out/git-semver) --build-arg GIT_COMMIT=$(shell git log -1 --format=%H) .
 
 .PHONY: push
 push: image

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,4 +1,15 @@
 FROM  quay.io/centos/centos:centos7.9.2009
 RUN yum install -y hwdata && yum clean -y all
 ADD _out/resource-topology-exporter /bin/resource-topology-exporter
+
+ARG GIT_COMMIT
+ARG VERSION
+RUN \
+    # Check for mandatory build arguments
+    : "${GIT_COMMIT:?Build argument needs to be set and non-empty.}" \
+    && : "${VERSION:?Build argument needs to be set and non-empty.}"
+
+LABEL org.opencontainers.image.revision=${GIT_COMMIT}
+LABEL org.opencontainers.image.version=${VERSION}
+
 ENTRYPOINT ["/bin/resource-topology-exporter"]


### PR DESCRIPTION
Add labels to the container image to hold the version and the git commit from which the binary was built.
Use opencontainer annotations defined
[here](https://github.com/opencontainers/image-spec/blob/main/annotations.md)


Issue: #150 