### PR TITLE
deflake event-based tests, another attempt

### DIFF
--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -56,7 +56,6 @@ const (
 var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func() {
 	var (
 		initialized         bool
-		timeout             time.Duration
 		topologyClient      *topologyclientset.Clientset
 		topologyUpdaterNode *corev1.Node
 		workerNodes         []corev1.Node
@@ -69,12 +68,6 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 		var err error
 
 		if !initialized {
-			timeout, err = time.ParseDuration(e2etestenv.GetPollInterval())
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			// wait interval exactly multiple of the poll interval makes the test racier and less robust, so
-			// add a little skew. We pick 1 second randomly, but the idea is that small (2, 3, 5) multipliers
-			// should again not cause a total multiple of the poll interval.
-			timeout += 1 * time.Second
 
 			topologyClient, err = topologyclientset.NewForConfig(f.ClientConfig())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -110,16 +103,42 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 			ginkgo.By("creating a pod consuming the shared pool")
 			sleeperPod := e2epods.MakeGuaranteedSleeperPod("1000m")
 
-			pod := f.PodClient().CreateSync(sleeperPod)
-			podNamespace, podName := pod.Namespace, pod.Name
-			cs := f.ClientSet
-			ginkgo.By("waiting for at least poll interval seconds with the test pod running...")
-			time.Sleep(timeout)
-			e2epods.DeletePodSyncByName(cs, podNamespace, podName)
+			updateInterval, method, err := estimateUpdateInterval(*initialNodeTopo)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			framework.Logf("%s update interval: %s", method, updateInterval)
+
+			// wait interval exactly multiple of the poll interval makes the test racier and less robust, so
+			// add a little skew. We pick 1 second randomly, but the idea is that small (2, 3, 5) multipliers
+			// should again not cause a total multiple of the poll interval.
+			pollingInterval := updateInterval + time.Second
+
+			stopChan := make(chan struct{})
+			doneChan := make(chan struct{})
+			started := false
+
+			go func() {
+				defer ginkgo.GinkgoRecover()
+
+				<-stopChan
+
+				pod := f.PodClient().CreateSync(sleeperPod)
+				podNamespace, podName := pod.Namespace, pod.Name
+				cs := f.ClientSet
+				ginkgo.By("waiting for at least poll interval seconds with the test pod running...")
+				time.Sleep(updateInterval * 3)
+				e2epods.DeletePodSyncByName(cs, podNamespace, podName)
+
+				doneChan <- struct{}{}
+			}()
 
 			ginkgo.By("getting the updated topology")
 			var finalNodeTopo *v1alpha1.NodeResourceTopology
 			gomega.Eventually(func() bool {
+				if !started {
+					stopChan <- struct{}{}
+					started = true
+				}
+
 				finalNodeTopo, err = topologyClient.TopologyV1alpha1().NodeResourceTopologies().Get(context.TODO(), topologyUpdaterNode.Name, metav1.GetOptions{})
 				if err != nil {
 					framework.Logf("failed to get the node topology resource: %v", err)
@@ -138,8 +157,14 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 				}
 				framework.Logf("resource %s reason %v expected %v", topologyUpdaterNode.Name, reason, nrtupdater.RTEUpdateReactive)
 				return reason == nrtupdater.RTEUpdateReactive
-			}, 5*timeout, timeout).Should(gomega.BeTrue(), "didn't get updated node topology info") // 5x timeout is a random "long enough" period
+			}).WithTimeout(updateInterval*9).WithPolling(pollingInterval).Should(gomega.BeTrue(), "didn't get updated node topology info") // 5x timeout is a random "long enough" period
 			ginkgo.By("checking the topology was updated for the right reason")
+
+			<-doneChan
+
+			gomega.Expect(finalNodeTopo.Annotations).ToNot(gomega.BeNil(), "missing annotations entirely")
+			reason := finalNodeTopo.Annotations[k8sannotations.RTEUpdate]
+			gomega.Expect(reason).To(gomega.Equal(nrtupdater.RTEUpdateReactive), "update reason error: expected %q got %q", nrtupdater.RTEUpdateReactive, reason)
 		})
 
 		ginkgo.It("[NotificationFile] it should react to pod changes using the smart poller with notification file", func() {

--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -215,7 +215,7 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 					return false
 				}
 				return reason == nrtupdater.RTEUpdateReactive
-			}).WithTimeout(5*time.Second).WithPolling(1*time.Second).Should(gomega.BeTrue(), "didn't get updated node topology info")
+			}).WithTimeout(31*time.Second).WithPolling(1*time.Second).Should(gomega.BeTrue(), "didn't get updated node topology info")
 			ginkgo.By("checking the topology was updated for the right reason")
 
 			<-doneChan

--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -215,7 +215,7 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 					return false
 				}
 				return reason == nrtupdater.RTEUpdateReactive
-			}, 5*time.Second, 1*time.Second).Should(gomega.BeTrue(), "didn't get updated node topology info")
+			}).WithTimeout(5*time.Second).WithPolling(1*time.Second).Should(gomega.BeTrue(), "didn't get updated node topology info")
 			ginkgo.By("checking the topology was updated for the right reason")
 
 			<-doneChan


### PR DESCRIPTION
generic improvement: clarify timeout and polling values using `With{Timeout,Polling}` helpers.
Specific fix to the `StateDirectories` test: use the same (more correct) layout as per the `NotificationFile` test, reverting earlier "fix".