### PR TITLE
e2e: fixes 20230207

### DIFF
--- a/test/e2e/utils/pods/pods.go
+++ b/test/e2e/utils/pods/pods.go
@@ -111,7 +111,7 @@ func DeletePodSyncByName(cs clientset.Interface, podNamespace, podName string) e
 	delOpts := metav1.DeleteOptions{
 		GracePeriodSeconds: &gp,
 	}
-	framework.Logf("Deleting pod %s/%s cs=%v", podNamespace, podName, cs)
+	framework.Logf("Deleting pod %s/%s", podNamespace, podName)
 	err := cs.CoreV1().Pods(podNamespace).Delete(context.TODO(), podName, delOpts)
 	if err != nil && !apierrors.IsNotFound(err) {
 		framework.Failf("Failed to delete pod %q: %v", podName, err)


### PR DESCRIPTION
we need to take a good look at our e2e suite and consider more heavy-handed approach because a lot of preconditions and assumptions are more and more be proven debatable or wrong.
For starters, however, address low-hanging fruits like panic on delete (which should never happen) and useless logs.

We will track overhaul of the suite separately.