### PR TITLE
notif: deprecate --kubelet-state-dir

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -100,7 +100,7 @@ func LoadArgs(args ...string) (ProgArgs, error) {
 	flags.StringVar(&pArgs.RTE.PodResourcesSocketPath, "podresources-socket", "unix:///podresources/kubelet.sock", "Pod Resource Socket path to use.")
 	flags.BoolVar(&pArgs.RTE.PodReadinessEnable, "podreadiness", true, "Custom condition injection using Podreadiness.")
 
-	kubeletStateDirs := flags.String("kubelet-state-dir", "", "Kubelet state directory (RO access needed), for smart polling.")
+	kubeletStateDirs := flags.String("kubelet-state-dir", "", "Kubelet state directory (RO access needed), for smart polling. **DEPRECATED** please use notify-file")
 	refCnt := flags.String("reference-container", "", "Reference container, used to learn about the shared cpu pool\n See: https://github.com/kubernetes/kubernetes/issues/102190\n format of spec is namespace/podname/containername.\n Alternatively, you can use the env vars REFERENCE_NAMESPACE, REFERENCE_POD_NAME, REFERENCE_CONTAINER_NAME.")
 
 	flags.StringVar(&pArgs.RTE.NotifyFilePath, "notify-file", "", "Notification file path.")

--- a/pkg/notification/notification.go
+++ b/pkg/notification/notification.go
@@ -162,6 +162,10 @@ func (es *UnlimitedEventSource) AddDirs(kubeletStateDirs []string) error {
 		return nil
 	}
 
+	klog.Infof("**DEPRECATED** watching state directories is insecure and has known issues")
+	klog.Infof("**DEPRECATED** watching state directories will be removed in a future version")
+	klog.Infof("**DEPRECATED** please use notification file instead")
+
 	dirCount := 0
 	for _, stateDir := range kubeletStateDirs {
 		klog.Infof("kubelet state dir: [%s]", stateDir)

--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -93,7 +93,7 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 	})
 
 	ginkgo.Context("with cluster configured", func() {
-		ginkgo.It("[StateDirectories] it should react to pod changes using the smart poller", func() {
+		ginkgo.It("[DEPRECATED][StateDirectories] it should react to pod changes using the smart poller", func() {
 			nodes, err := e2enodes.FilterNodesWithEnoughCores(workerNodes, "1000m")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			if len(nodes) < 1 {


### PR DESCRIPTION
The file-based notification is easier to secure and more reliable, because the state-dir approach handles deletion events with unavoidable delay - this is just how kubelet operates, we can't fix this.

Signed-off-by: Francesco Romani <fromani@redhat.com>