### PR TITLE
config: add support to get kubelet params

### DIFF
--- a/test/data/rteconfig/kubelet_tm_full.yaml
+++ b/test/data/rteconfig/kubelet_tm_full.yaml
@@ -1,0 +1,3 @@
+kubelet:
+  topologyManagerPolicy: restricted
+  topologyManagerScope: pod

--- a/test/e2e/utils/runtime.go
+++ b/test/e2e/utils/runtime.go
@@ -7,6 +7,7 @@ import (
 )
 
 var BinariesPath string
+var TestDataPath string
 
 func init() {
 
@@ -17,4 +18,5 @@ func init() {
 
 	baseDir := filepath.Dir(file)
 	BinariesPath = filepath.Clean(filepath.Join(baseDir, "..", "..", "..", "./_out"))
+	TestDataPath = filepath.Clean(filepath.Join(baseDir, "..", "..", "..", "test", "data"))
 }


### PR DESCRIPTION
Add support to read kubelet (topology manager) params from the config file, alongside the regular command line parameters.

For backward compatibility (and per unix traditions), the command line params still take precedence over the config file.