### PR TITLE
pfp: expose computation method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/go-cmp v0.5.8
 	github.com/jaypipes/ghw v0.9.0
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.0
-	github.com/k8stopologyawareschedwg/podfingerprint v0.1.2
+	github.com/k8stopologyawareschedwg/podfingerprint v0.2.1
 	github.com/mdomke/git-semver v1.0.0
 	github.com/onsi/ginkgo/v2 v2.4.0
 	github.com/onsi/gomega v1.22.1

--- a/go.sum
+++ b/go.sum
@@ -408,8 +408,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.0 h1:2uCRJbv+A+fmaUaO0wLZ8oYd6cLE1dRzBQcFNxggH3s=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.0/go.mod h1:AkACMQGiTgCt0lQw3m7TTU8PLH9lYKNK5e9DqFf5VuM=
-github.com/k8stopologyawareschedwg/podfingerprint v0.1.2 h1:Db5KLJjPg2mKaCoeEliMlea+JMyDMWdbNPXnWbPNDyM=
-github.com/k8stopologyawareschedwg/podfingerprint v0.1.2/go.mod h1:C23pM15t06dXg/OihGlqBvnYzLr+MXDXJ7zMfbNAyXI=
+github.com/k8stopologyawareschedwg/podfingerprint v0.2.1 h1:Ggdtpl9vZ3weUw63suPh2T6BCQpUTx8b9MJj29uXvKk=
+github.com/k8stopologyawareschedwg/podfingerprint v0.2.1/go.mod h1:C23pM15t06dXg/OihGlqBvnYzLr+MXDXJ7zMfbNAyXI=
 github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/pkg/resourcemonitor/resourcemonitor.go
+++ b/pkg/resourcemonitor/resourcemonitor.go
@@ -205,6 +205,13 @@ func WithNodeName(name string) func(*resourceMonitor) {
 	}
 }
 
+func pfpMethodToString(args Args) string {
+	if args.PodSetFingerprintUnrestricted {
+		return podfingerprint.MethodAll
+	}
+	return podfingerprint.MethodWithExclusiveResources
+}
+
 func (rm *resourceMonitor) Scan(excludeList ResourceExclude) (ScanResponse, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultPodResourcesTimeout)
 	defer cancel()
@@ -231,6 +238,10 @@ func (rm *resourceMonitor) Scan(excludeList ResourceExclude) (ScanResponse, erro
 		scanRes.Attributes = append(scanRes.Attributes, topologyv1alpha2.AttributeInfo{
 			Name:  podfingerprint.Attribute,
 			Value: pfpSign,
+		})
+		scanRes.Attributes = append(scanRes.Attributes, topologyv1alpha2.AttributeInfo{
+			Name:  podfingerprint.AttributeMethod,
+			Value: pfpMethodToString(rm.args),
 		})
 		scanRes.Annotations[podfingerprint.Annotation] = pfpSign
 		klog.V(6).Infof("pfp: " + st.Repr())

--- a/pkg/resourcemonitor/resourcemonitor.go
+++ b/pkg/resourcemonitor/resourcemonitor.go
@@ -214,7 +214,7 @@ func (rm *resourceMonitor) Scan(excludeList ResourceExclude) (ScanResponse, erro
 		return ScanResponse{}, err
 	}
 
-	var st podfingerprint.Status
+	st := podfingerprint.MakeStatus(rm.nodeName)
 	scanRes := ScanResponse{
 		Attributes:  topologyv1alpha2.AttributeList{},
 		Annotations: map[string]string{},

--- a/vendor/github.com/k8stopologyawareschedwg/podfingerprint/podfingerprint.go
+++ b/vendor/github.com/k8stopologyawareschedwg/podfingerprint/podfingerprint.go
@@ -51,6 +51,15 @@ const (
 	// Attribute is the recommended attribute name to use in
 	// NodeResourceTopology objects
 	Attribute = "nodeTopologyPodsFingerprint"
+	// AttributeMethod is the recommended attribute name to use
+	// in NodeResourceTopology objects to declare how the
+	// fingerprint was being computed
+	AttributeMethod = "nodeTopologyPodsFingerprintMethod"
+)
+
+const (
+	MethodAll                    = "all"                      // unrestricted. Just compute all the pods
+	MethodWithExclusiveResources = "with-exclusive-resources" // only consider pods which require exclusive resources
 )
 
 const (

--- a/vendor/github.com/k8stopologyawareschedwg/podfingerprint/tracing.go
+++ b/vendor/github.com/k8stopologyawareschedwg/podfingerprint/tracing.go
@@ -65,6 +65,13 @@ type Status struct {
 	FingerprintExpected string           `json:"fingerprintExpected,omitempty"`
 	FingerprintComputed string           `json:"fingerprintComputed,omitempty"`
 	Pods                []NamespacedName `json:"pods,omitempty"`
+	NodeName            string           `json:"nodeName,omitempty"`
+}
+
+func MakeStatus(nodeName string) Status {
+	return Status{
+		NodeName: nodeName,
+	}
 }
 
 func (st *Status) Start(numPods int) {
@@ -90,6 +97,7 @@ func (st *Status) Check(expected string) {
 func (st Status) Repr() string {
 	var sb strings.Builder
 
+	sb.WriteString(fmt.Sprintf("> processing node %q\n", st.NodeName))
 	sb.WriteString(fmt.Sprintf("> processing %d pods\n", len(st.Pods)))
 	for _, pod := range st.Pods {
 		sb.WriteString("+ " + pod.Namespace + "/" + pod.Name + "\n")
@@ -101,6 +109,18 @@ func (st Status) Repr() string {
 	}
 
 	return sb.String()
+}
+
+func (st Status) Clone() Status {
+	pods := make([]NamespacedName, len(st.Pods))
+	copy(pods, st.Pods)
+	ret := Status{
+		FingerprintExpected: st.FingerprintExpected,
+		FingerprintComputed: st.FingerprintComputed,
+		Pods:                pods,
+		NodeName:            st.NodeName,
+	}
+	return ret
 }
 
 type TracingFingerprint struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -470,7 +470,7 @@ github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/client
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned/typed/topology/v1alpha1/fake
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned/typed/topology/v1alpha2
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned/typed/topology/v1alpha2/fake
-# github.com/k8stopologyawareschedwg/podfingerprint v0.1.2
+# github.com/k8stopologyawareschedwg/podfingerprint v0.2.1
 ## explicit; go 1.17
 github.com/k8stopologyawareschedwg/podfingerprint
 # github.com/karrick/godirwalk v1.16.1


### PR DESCRIPTION
recently we gained a way to compute the PFP directly, considering all pods (standard behavior up until now) or only pods with exclusive resources allocated to them.

Expose the computation method as NRT attribute, to enable the consumers to know explicitely how the PFP was computed and react accordingly.