### PR TITLE
[manual][release-0.11] resmon: fix the error message

### DIFF
--- a/pkg/resourcemonitor/resourcemonitor.go
+++ b/pkg/resourcemonitor/resourcemonitor.go
@@ -332,7 +332,7 @@ func (rm *resourceMonitor) Scan(excludeList ResourceExclude) (ScanResponse, erro
 	if rm.args.PodSetFingerprint && rm.args.PodSetFingerprintStatusFile != "" {
 		dir, file := filepath.Split(rm.args.PodSetFingerprintStatusFile)
 		err := toFile(st, dir, file)
-		klog.V(6).InfoS("error dumping the pfp status to %q (%v): %v", rm.args.PodSetFingerprintStatusFile, file, err)
+		klog.V(6).InfoS("error dumping the pfp status", "fullPath", rm.args.PodSetFingerprintStatusFile, "statusFile", file, "err", err)
 		// intentionally ignore error, we must keep going.
 	}
 	return scanRes, nil


### PR DESCRIPTION
It's InfoS, so it uses a different format. Fix accordingly. Note the issue is only cosmetic, the code is NOT crashing.

backport of #182 