### PR TITLE
ghactions: pin the runners to 22.04

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ defaults:
 
 jobs:
   e2e-ic:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       # TODO
       RTE_CONTAINER_IMAGE: quay.io/k8stopologyawarewg/resource-topology-exporter:ci

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ defaults:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       RTE_CONTAINER_IMAGE: quay.io/k8stopologyawareschedwg/resource-topology-exporter
       E2E_TOPOLOGY_MANAGER_POLICY: SingleNUMANodeContainerLevel


### PR DESCRIPTION
time to update from the ancient 20.04.
Explicitely pin a version rather than follow the -latest floating tag.