### PR TITLE
e2e: consistent target node pick

### DIFF
--- a/test/e2e/rte/metrics.go
+++ b/test/e2e/rte/metrics.go
@@ -37,6 +37,7 @@ import (
 	e2enodes "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/nodes"
 	e2epods "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/pods"
 	e2ertepod "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/pods/rtepod"
+	e2econsts "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/testconsts"
 	e2etestenv "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/testenv"
 )
 
@@ -69,11 +70,21 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 
 			workerNodes, err = e2enodes.GetWorkerNodes(f)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(workerNodes).ToNot(gomega.BeEmpty())
 
 			// pick any worker node. The (implicit, TODO: make explicit) assumption is
 			// the daemonset runs on CI on all the worker nodes.
-			topologyUpdaterNode = &workerNodes[0]
+			var hasLabel bool
+			topologyUpdaterNode, hasLabel = e2enodes.PickTargetNode(workerNodes)
 			gomega.Expect(topologyUpdaterNode).NotTo(gomega.BeNil())
+			if !hasLabel {
+				// during the e2e tests we expect changes on the node topology.
+				// but in an environment with multiple worker nodes, we might be looking at the wrong node.
+				// thus, we assign a unique label to the picked worker node
+				// and making sure to deploy the pod on it during the test using nodeSelector
+				err = e2enodes.LabelNode(f, topologyUpdaterNode, map[string]string{e2econsts.TestNodeLabel: ""})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			}
 
 			initialized = true
 		}

--- a/test/e2e/utils/nodes/nodes.go
+++ b/test/e2e/utils/nodes/nodes.go
@@ -27,6 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/kubernetes/test/e2e/framework"
+
+	e2etestconsts "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/testconsts"
 )
 
 const (
@@ -117,4 +119,21 @@ func LabelNode(f *framework.Framework, node *corev1.Node, newLabels map[string]s
 
 	_, err = f.ClientSet.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.JSONPatchType, payloadBytes, metav1.PatchOptions{})
 	return err
+}
+
+func PickTargetNode(workerNodes []corev1.Node) (*corev1.Node, bool) {
+	if len(workerNodes) == 0 {
+		return nil, false
+	}
+
+	for idx := range workerNodes {
+		node := &workerNodes[idx]
+		if node.Labels != nil {
+			if _, ok := node.Labels[e2etestconsts.TestNodeLabel]; ok {
+				return node, true
+			}
+		}
+	}
+
+	return &workerNodes[0], false // any node is fine.
 }


### PR DESCRIPTION
Improve the way we select and label the target node, adding a helper function to pick it and ensure that already labelled nodes are consistently picked up.