### PR TITLE
[release-0.12][manual] e2e: explicit namespace creation

### DIFF
--- a/test/e2e/rte/metrics.go
+++ b/test/e2e/rte/metrics.go
@@ -35,6 +35,7 @@ import (
 	k8se2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	admissionapi "k8s.io/pod-security-admission/api"
 
+	e2etestns "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/namespace"
 	e2enodes "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/nodes"
 	e2epods "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/pods"
 	e2ertepod "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/pods/rtepod"
@@ -53,10 +54,15 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 
 	f := framework.NewDefaultFramework("metrics")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	f.SkipNamespaceCreation = true
 
 	ginkgo.BeforeEach(func() {
+		var err error
+
+		err = e2etestns.Setup(f)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 		if !initialized {
-			var err error
 			var pods *corev1.PodList
 			sel, err := labels.Parse(fmt.Sprintf("name=%s", e2etestenv.RTELabelName))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -43,6 +43,7 @@ import (
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/k8sannotations"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/nrtupdater"
 
+	e2etestns "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/namespace"
 	e2enodes "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/nodes"
 	e2enodetopology "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/nodetopology"
 	e2epods "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/pods"
@@ -65,12 +66,15 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 
 	f := framework.NewDefaultFramework("rte")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	f.SkipNamespaceCreation = true
 
 	ginkgo.BeforeEach(func() {
 		var err error
 
-		if !initialized {
+		err = e2etestns.Setup(f)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+		if !initialized {
 			topologyClient, err = topologyclientset.NewForConfig(f.ClientConfig())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -409,7 +409,7 @@ func dumpPods(f *framework.Framework, nodeName, message string) {
 
 	framework.Logf("BEGIN pods running on %q: %s", nodeName, message)
 	for _, pod := range pods.Items {
-		framework.Logf("%s %s/%s annotations=%v status=%s (%s %s)", nodeName, pod.Namespace, pod.Name, pod.Annotations, pod.Status.Phase, pod.Status.Message, pod.Status.Reason)
+		framework.Logf("%s %s/%s status=%s (%s %s)", nodeName, pod.Namespace, pod.Name, pod.Status.Phase, pod.Status.Message, pod.Status.Reason)
 	}
 	framework.Logf("END pods running on %q: %s", nodeName, message)
 }

--- a/test/e2e/topology_updater/topology_updater.go
+++ b/test/e2e/topology_updater/topology_updater.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	topologyclientset "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned"
+	e2etestns "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/namespace"
 	e2enodes "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/nodes"
 	e2enodetopology "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/nodetopology"
 	e2epods "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils/pods"
@@ -58,9 +59,13 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 
 	f := framework.NewDefaultFramework("topology-updater")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	f.SkipNamespaceCreation = true
 
 	ginkgo.BeforeEach(func() {
 		var err error
+
+		err = e2etestns.Setup(f)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		if !initialized {
 			timeout, err = time.ParseDuration(e2etestenv.GetPollInterval())

--- a/test/e2e/topology_updater/topology_updater.go
+++ b/test/e2e/topology_updater/topology_updater.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	k8se2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	admissionapi "k8s.io/pod-security-admission/api"
+	"sigs.k8s.io/yaml"
 
 	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	topologyclientset "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned"
@@ -231,7 +232,15 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 		ginkgo.It("should fill the node resource topologies CR with the data", func() {
 			nodeTopology := e2enodetopology.GetNodeTopology(topologyClient, topologyUpdaterNode.Name)
 			isValid := e2enodetopology.IsValidNodeTopology(nodeTopology, tmPolicy, tmScope)
-			gomega.Expect(isValid).To(gomega.BeTrue(), "received invalid topology: %v", nodeTopology)
+			gomega.Expect(isValid).To(gomega.BeTrue(), "received invalid topology:\n%v", toYAML(nodeTopology))
 		})
 	})
 })
+
+func toYAML(obj interface{}) string {
+	data, err := yaml.Marshal(obj)
+	if err != nil {
+		return fmt.Sprintf("<SERIALIZE ERROR: %v>", err)
+	}
+	return string(data)
+}

--- a/test/e2e/utils/namespace/namespace.go
+++ b/test/e2e/utils/namespace/namespace.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import "k8s.io/kubernetes/test/e2e/framework"
+
+var (
+	Labels map[string]string
+)
+
+func Setup(f *framework.Framework) error {
+	nsLabels := map[string]string{
+		"e2e-framework": f.BaseName,
+	}
+	for key, value := range Labels {
+		nsLabels[key] = value
+	}
+	namespace, err := f.CreateNamespace(f.BaseName, nsLabels)
+	if err != nil {
+		return err
+	}
+	f.Namespace = namespace
+	return nil
+}

--- a/test/e2e/utils/nodetopology/nodetopology.go
+++ b/test/e2e/utils/nodetopology/nodetopology.go
@@ -18,9 +18,11 @@ package nodetopology
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
+	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
 	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
@@ -45,6 +47,8 @@ func GetNodeTopology(topologyClient *topologyclientset.Clientset, nodeName strin
 }
 
 func GetNodeTopologyWithResource(topologyClient *topologyclientset.Clientset, nodeName, resName string) *v1alpha2.NodeResourceTopology {
+	ginkgo.By(fmt.Sprintf("getting NRT for node=%q resource=%q", nodeName, resName))
+
 	var nodeTopology *v1alpha2.NodeResourceTopology
 	var err error
 	gomega.EventuallyWithOffset(1, func() bool {
@@ -58,6 +62,7 @@ func GetNodeTopologyWithResource(topologyClient *topologyclientset.Clientset, no
 		}
 		return containsResource(nodeTopology, resName)
 	}, time.Minute, 5*time.Second).Should(gomega.BeTrue())
+
 	return nodeTopology
 }
 


### PR DESCRIPTION
Create the test namespace explicitely, instead of letting the framework do it. This is helpful to
enable namespace customization, like label injection.

Additional improvements to logging to make troubleshooting easier