### PR TITLE
images: bump to centos8

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM  quay.io/centos/centos:centos7.9.2009
+FROM  quay.io/centos/centos:8
 RUN yum install -y hwdata && yum clean -y all
 ADD _out/resource-topology-exporter /bin/resource-topology-exporter
 

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,4 +1,7 @@
 FROM  quay.io/centos/centos:8
+RUN cd /etc/yum.repos.d/ && \
+	sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+	sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 RUN yum install -y hwdata && yum clean -y all
 ADD _out/resource-topology-exporter /bin/resource-topology-exporter
 


### PR DESCRIPTION
The centos 7 image is too old, let's bump to 8. We will probably update again soon, but one step at time.

Fixes: #175 