### PR TITLE
k8s: client: use common client

### DIFF
--- a/cmd/resource-topology-exporter/main.go
+++ b/cmd/resource-topology-exporter/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podres/middleware/sharedcpuspool"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podres/middleware/terminalpods"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/prometheus"
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcemonitor"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcetopologyexporter"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/version"
 )
@@ -51,6 +52,11 @@ func main() {
 		os.Exit(0)
 	}
 
+	k8scli, err := k8shelpers.GetK8sClient("")
+	if err != nil {
+		klog.Fatalf("failed to get k8s client: %w", err)
+	}
+
 	cli, err := podres.GetClient(parsedArgs.RTE.PodResourcesSocketPath)
 	if err != nil {
 		klog.Fatalf("failed to get podresources client: %v", err)
@@ -64,10 +70,6 @@ func main() {
 
 	if parsedArgs.Resourcemonitor.ExcludeTerminalPods {
 		klog.Infof("terminal pods are filtered from the PodResourcesLister client")
-		k8scli, err := k8shelpers.GetK8sClient("")
-		if err != nil {
-			klog.Fatalf("failed to get k8s client: %w", err)
-		}
 		cli, err = terminalpods.NewFromLister(context.TODO(), cli, k8scli, time.Minute, parsedArgs.RTE.Debug)
 		if err != nil {
 			klog.Fatalf("failed to get PodResourceAPI client: %w", err)
@@ -79,7 +81,11 @@ func main() {
 		klog.Fatalf("failed to start prometheus server: %v", err)
 	}
 
-	err = resourcetopologyexporter.Execute(cli, parsedArgs.NRTupdater, parsedArgs.Resourcemonitor, parsedArgs.RTE)
+	hnd := resourcemonitor.Handle{
+		PodResCli: cli,
+		K8SCli:    k8scli,
+	}
+	err = resourcetopologyexporter.Execute(hnd, parsedArgs.NRTupdater, parsedArgs.Resourcemonitor, parsedArgs.RTE)
 	if err != nil {
 		klog.Fatalf("failed to execute: %v", err)
 	}

--- a/pkg/podreadiness/conditioninjector.go
+++ b/pkg/podreadiness/conditioninjector.go
@@ -9,17 +9,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
-
-	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/k8shelpers"
 )
 
 type ConditionInjector struct {
-	cs      *kubernetes.Clientset
+	cs      kubernetes.Interface
 	ns      string
 	podName string
 }
 
-func NewConditionInjector() (*ConditionInjector, error) {
+func NewConditionInjector(cs kubernetes.Interface) (*ConditionInjector, error) {
 	nsVal, ok := os.LookupEnv("REFERENCE_NAMESPACE")
 	if !ok {
 		return nil, fmt.Errorf("the env REFERENCE_NAMESPACE doesn't exist")
@@ -28,11 +26,6 @@ func NewConditionInjector() (*ConditionInjector, error) {
 	podVal, ok := os.LookupEnv("REFERENCE_POD_NAME")
 	if !ok {
 		return nil, fmt.Errorf("the env REFERENCE_POD_NAME doesn't exist")
-	}
-
-	cs, err := k8shelpers.GetK8sClient("")
-	if err != nil {
-		return nil, err
 	}
 
 	return &ConditionInjector{

--- a/pkg/resourcemonitor/resourcemonitor.go
+++ b/pkg/resourcemonitor/resourcemonitor.go
@@ -42,7 +42,6 @@ import (
 	topologyv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 	"github.com/k8stopologyawareschedwg/podfingerprint"
 
-	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/k8shelpers"
 	podresfilter "github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podres/filter"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podres/filter/numalocality"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podres/middleware/podexclude"
@@ -68,6 +67,11 @@ type Args struct {
 	PodSetFingerprintStatusFile string
 	PodExclude                  podexclude.List
 	ExcludeTerminalPods         bool
+}
+
+type Handle struct {
+	PodResCli podresourcesapi.PodResourcesListerClient
+	K8SCli    kubernetes.Interface
 }
 
 type ScanResponse struct {
@@ -132,9 +136,10 @@ type resourceMonitor struct {
 	nodeAllocatable   perNUMAResourceCounter
 }
 
-func NewResourceMonitor(podResCli podresourcesapi.PodResourcesListerClient, args Args, options ...func(*resourceMonitor)) (*resourceMonitor, error) {
+func NewResourceMonitor(hnd Handle, args Args, options ...func(*resourceMonitor)) (*resourceMonitor, error) {
 	rm := &resourceMonitor{
-		podResCli: podResCli,
+		podResCli: hnd.PodResCli,
+		k8sCli:    hnd.K8SCli,
 		args:      args,
 	}
 	for _, opt := range options {
@@ -165,14 +170,6 @@ func NewResourceMonitor(podResCli podresourcesapi.PodResourcesListerClient, args
 		}
 	} else {
 		klog.Infof("tracking node resources")
-		if rm.k8sCli == nil {
-			c, err := k8shelpers.GetK8sClient("")
-			if err != nil {
-				return nil, err
-			}
-			rm.k8sCli = c
-		}
-
 		if err := rm.updateNodeResources(); err != nil {
 			return nil, err
 		}

--- a/pkg/resourcemonitor/resourcemonitor_test.go
+++ b/pkg/resourcemonitor/resourcemonitor_test.go
@@ -456,7 +456,7 @@ func TestResourcesScan(t *testing.T) {
 
 		mockPodResClient := new(podres.MockPodResourcesListerClient)
 		mockPodResClient.On("GetAllocatableResources", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.AllocatableResourcesRequest")).Return(availRes, nil)
-		resMon, err := NewResourceMonitor(mockPodResClient, Args{}, WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
+		resMon, err := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{}, WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
 		So(err, ShouldBeNil)
 
 		Convey("When aggregating resources", func() {
@@ -553,7 +553,7 @@ func TestResourcesScan(t *testing.T) {
 
 		mockPodResClient := new(podres.MockPodResourcesListerClient)
 		mockPodResClient.On("GetAllocatableResources", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.AllocatableResourcesRequest")).Return(availRes, nil)
-		resMon, err := NewResourceMonitor(mockPodResClient, Args{}, WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
+		resMon, err := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{}, WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
 		So(err, ShouldBeNil)
 
 		Convey("When aggregating resources", func() {
@@ -706,7 +706,7 @@ func TestResourcesScan(t *testing.T) {
 
 		mockPodResClient := new(podres.MockPodResourcesListerClient)
 		mockPodResClient.On("GetAllocatableResources", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.AllocatableResourcesRequest")).Return(allocRes, nil)
-		resMon, err := NewResourceMonitor(mockPodResClient, Args{}, WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
+		resMon, err := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{}, WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
 		So(err, ShouldBeNil)
 
 		Convey("When aggregating resources", func() {
@@ -877,7 +877,7 @@ func TestResourcesScan(t *testing.T) {
 
 		mockPodResClient := new(podres.MockPodResourcesListerClient)
 		mockPodResClient.On("GetAllocatableResources", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.AllocatableResourcesRequest")).Return(allocRes, nil)
-		resMon, err := NewResourceMonitor(mockPodResClient, Args{}, WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
+		resMon, err := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{}, WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
 		So(err, ShouldBeNil)
 
 		Convey("When aggregating resources", func() {
@@ -1100,7 +1100,7 @@ func TestResourcesScan(t *testing.T) {
 		}
 		mockPodResClient := new(podres.MockPodResourcesListerClient)
 		mockPodResClient.On("GetAllocatableResources", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.AllocatableResourcesRequest")).Return(allocRes, nil)
-		resMon, err := NewResourceMonitor(mockPodResClient, Args{RefreshNodeResources: true}, WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
+		resMon, err := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{RefreshNodeResources: true}, WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
 		So(err, ShouldBeNil)
 
 		Convey("When aggregating resources", func() {
@@ -1270,7 +1270,7 @@ func TestResourcesScan(t *testing.T) {
 
 		mockPodResClient := new(podres.MockPodResourcesListerClient)
 		mockPodResClient.On("GetAllocatableResources", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.AllocatableResourcesRequest")).Return(availRes, nil)
-		resMon, err := NewResourceMonitor(mockPodResClient, Args{PodSetFingerprint: true}, WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
+		resMon, err := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{PodSetFingerprint: true}, WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
 		So(err, ShouldBeNil)
 
 		Convey("When aggregating resources", func() {

--- a/pkg/resourcetopologyexporter/resourceobserver.go
+++ b/pkg/resourcetopologyexporter/resourceobserver.go
@@ -6,7 +6,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
-	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/k8sannotations"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/notification"
@@ -25,8 +24,8 @@ type ResourceObserver struct {
 	exposeTiming    bool
 }
 
-func NewResourceObserver(cli podresourcesapi.PodResourcesListerClient, args resourcemonitor.Args) (*ResourceObserver, error) {
-	resMon, err := resourcemonitor.NewResourceMonitor(cli, args)
+func NewResourceObserver(hnd resourcemonitor.Handle, args resourcemonitor.Args) (*ResourceObserver, error) {
+	resMon, err := resourcemonitor.NewResourceMonitor(hnd, args)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize ResourceMonitor: %w", err)
 	}

--- a/pkg/resourcetopologyexporter/resourcetopologyexporter.go
+++ b/pkg/resourcetopologyexporter/resourcetopologyexporter.go
@@ -6,7 +6,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
-	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/kubeconf"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/notification"
@@ -36,7 +35,7 @@ type tmSettings struct {
 	config nrtupdater.TMConfig
 }
 
-func Execute(cli podresourcesapi.PodResourcesListerClient, nrtupdaterArgs nrtupdater.Args, resourcemonitorArgs resourcemonitor.Args, rteArgs Args) error {
+func Execute(hnd resourcemonitor.Handle, nrtupdaterArgs nrtupdater.Args, resourcemonitorArgs resourcemonitor.Args, rteArgs Args) error {
 	tmConf, err := getTopologyManagerSettings(rteArgs)
 	if err != nil {
 		return err
@@ -45,7 +44,7 @@ func Execute(cli podresourcesapi.PodResourcesListerClient, nrtupdaterArgs nrtupd
 	var condChan chan v1.PodCondition
 	if rteArgs.PodReadinessEnable {
 		condChan = make(chan v1.PodCondition)
-		condIn, err := podreadiness.NewConditionInjector()
+		condIn, err := podreadiness.NewConditionInjector(hnd.K8SCli)
 		if err != nil {
 			return err
 		}
@@ -57,7 +56,7 @@ func Execute(cli podresourcesapi.PodResourcesListerClient, nrtupdaterArgs nrtupd
 		return err
 	}
 
-	resObs, err := NewResourceObserver(cli, resourcemonitorArgs)
+	resObs, err := NewResourceObserver(hnd, resourcemonitorArgs)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Instead of creating a client in the relevant packages, accept a client from the caller and reuse the common client.

Fixes: #185 