### PR TITLE
e2e: pass correct args to `DeferCleanup`

### DIFF
--- a/test/e2e/rte/metrics.go
+++ b/test/e2e/rte/metrics.go
@@ -127,9 +127,7 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 			pod, err := e2epods.CreateSync(f, sleeperPod)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			ginkgo.DeferCleanup(func(f *fixture.Fixture, podNamespace, podName string) error {
-				return e2epods.DeletePodSyncByName(f, podNamespace, podName)
-			}, f, pod.Namespace, pod.Name)
+			ginkgo.DeferCleanup(e2epods.DeletePodSyncByName, f, pod.Namespace, pod.Name)
 
 			// now we are sure we have at least a write to be reported
 			rteContainerName, err := e2ertepod.FindRTEContainerName(rtePod)

--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -319,7 +319,7 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			// (try to) delete the pod twice is no bother
 			podNamespace, podName := pod.Namespace, pod.Name
-			ginkgo.DeferCleanup(e2epods.DeletePodSyncByName, f.K8SCli, podNamespace, podName)
+			ginkgo.DeferCleanup(e2epods.DeletePodSyncByName, f, podNamespace, podName)
 
 			currNrt = getUpdatedNRT(f.TopoCli, topologyUpdaterNode.Name, *prevNrt, updateInterval)
 

--- a/test/e2e/topology_updater/topology_updater.go
+++ b/test/e2e/topology_updater/topology_updater.go
@@ -31,7 +31,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/yaml"
@@ -108,9 +107,7 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 			pod, err := e2epods.CreateSync(f, sleeperPod)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			ginkgo.DeferCleanup(func(cs clientset.Interface, podNamespace, podName string) error {
-				return e2epods.DeletePodSyncByName(f, podNamespace, podName)
-			}, f.K8SCli, pod.Namespace, pod.Name)
+			ginkgo.DeferCleanup(e2epods.DeletePodSyncByName, f, pod.Namespace, pod.Name)
 
 			cooldown := 3 * timeout
 			ginkgo.By(fmt.Sprintf("getting the updated topology - sleeping for %v", cooldown))
@@ -149,9 +146,7 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 
 			pod, err := e2epods.CreateSync(f, sleeperPod)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			ginkgo.DeferCleanup(func(cs clientset.Interface, podNamespace, podName string) error {
-				return e2epods.DeletePodSyncByName(f, podNamespace, podName)
-			}, f.K8SCli, pod.Namespace, pod.Name)
+			ginkgo.DeferCleanup(e2epods.DeletePodSyncByName, f, pod.Namespace, pod.Name)
 
 			cooldown := 3 * timeout
 			ginkgo.By(fmt.Sprintf("getting the updated topology - sleeping for %v", cooldown))
@@ -198,9 +193,7 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 
 			pod, err := e2epods.CreateSync(f, sleeperPod)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			ginkgo.DeferCleanup(func(cs clientset.Interface, podNamespace, podName string) error {
-				return e2epods.DeletePodSyncByName(f, podNamespace, podName)
-			}, f.K8SCli, pod.Namespace, pod.Name)
+			ginkgo.DeferCleanup(e2epods.DeletePodSyncByName, f, pod.Namespace, pod.Name)
 
 			ginkgo.By("getting the updated topology")
 			var finalNodeTopo *v1alpha2.NodeResourceTopology


### PR DESCRIPTION
The `e2epods.DeletePodSyncByName` invoked by `DeferCleanup` expects a Fixture and not a k8s client interface.

In addition simplifies the way of passing args to `DeferCleanup`