### PR TITLE
e2e: utils: nodes: improve RTE metrics test troubleshooting

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -83,7 +83,7 @@ jobs:
     - name: run E2E tests
       run: |
         export KUBECONFIG=${HOME}/.kube/config 
-        _out/rte-e2e.test -ginkgo.focus='\[(RTE|TopologyUpdater)\].*\[(Local|InfraConsuming|Monitoring)\]'
+        _out/rte-e2e.test -ginkgo.v -ginkgo.focus='\[(RTE|TopologyUpdater)\].*\[(Local|InfraConsuming|Monitoring)\]'
 
     - name: show RTE logs
       if: ${{ failure() }}

--- a/test/e2e/rte/metrics.go
+++ b/test/e2e/rte/metrics.go
@@ -23,9 +23,10 @@ package rte
 import (
 	"context"
 	"fmt"
-	"k8s.io/klog/v2"
 	"strings"
 	"time"
+
+	"k8s.io/klog/v2"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -112,7 +113,7 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 				gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed exec command on pod. pod=%q; cmd=%q; err=%v; stderr=%q", key.String(), cmd, err, stderr)
 				return strings.Contains(string(stdout), "operation_delay") &&
 					strings.Contains(string(stdout), "wakeup_delay")
-			}).WithPolling(10*time.Second).WithTimeout(2*time.Minute).Should(gomega.BeTrue(), "failed to get metrics from pod\nstdout=%q\nstderr=%q\n", stdout, stderr)
+			}).WithPolling(10*time.Second).WithTimeout(3*time.Minute).Should(gomega.BeTrue(), "failed to get metrics from pod\nstdout=%q\nstderr=%q\n", stdout, stderr)
 		})
 		ginkgo.It("[release] it should report noderesourcetopology writes", func() {
 			nodes, err := e2enodes.FilterNodesWithEnoughCores(workerNodes, "1000m")

--- a/test/e2e/utils/nodes/nodes.go
+++ b/test/e2e/utils/nodes/nodes.go
@@ -74,7 +74,7 @@ func GetNodesBySelector(cs kubernetes.Interface, selector labels.Selector) ([]co
 // FilterNodesWithEnoughCores returns all nodes with at least the amount of given CPU allocatable
 func FilterNodesWithEnoughCores(nodes []corev1.Node, cpuAmount string) ([]corev1.Node, error) {
 	requestCpu := resource.MustParse(cpuAmount)
-	klog.Infof("checking request %v on %d nodes", requestCpu, len(nodes))
+	klog.Infof("checking request %v on %d nodes", requestCpu.String(), len(nodes))
 
 	resNodes := []corev1.Node{}
 	for _, node := range nodes {
@@ -84,7 +84,7 @@ func FilterNodesWithEnoughCores(nodes []corev1.Node, cpuAmount string) ([]corev1
 		}
 
 		if availCpu.Cmp(requestCpu) < 1 {
-			klog.Infof("node %q available cpu %v requested cpu %v", node.Name, availCpu, requestCpu)
+			klog.Infof("node %q available cpu %v requested cpu %v", node.Name, availCpu.String(), requestCpu.String())
 			continue
 		}
 


### PR DESCRIPTION
If memory serves, metrics just always take some time before to be populated (that's expected, documented and bening, but of course I don't have docs handy). If the metrics test executes too early, because ginkgo random ordering, that could explain the flakiness.

This PR won't fix the flakiness but will make it easier to understand if this is indeed the case.