### PR TITLE
[release-0.14][manual] e2e: noderef: allow to skip test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,7 @@ jobs:
       RTE_CONTAINER_IMAGE: quay.io/k8stopologyawarewg/resource-topology-exporter:ci
       E2E_TOPOLOGY_MANAGER_POLICY: single-numa-node
       E2E_TOPOLOGY_MANAGER_SCOPE: container
+      E2E_NODE_REFERENCE: true
       RTE_POLL_INTERVAL: 10s
       RTE_VERBOSE: 6
     steps:

--- a/test/e2e/topology_updater/topology_updater.go
+++ b/test/e2e/topology_updater/topology_updater.go
@@ -51,6 +51,7 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 		timeout             time.Duration
 		tmPolicy            string
 		tmScope             string
+		hasNodeRef          bool
 		topologyUpdaterNode *corev1.Node
 		workerNodes         []corev1.Node
 	)
@@ -91,6 +92,7 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 
 			tmPolicy = e2etestenv.GetTopologyManagerPolicy()
 			tmScope = e2etestenv.GetTopologyManagerScope()
+			hasNodeRef = e2etestenv.GetNodeReferenceEnabled()
 
 			initialized = true
 		}
@@ -98,6 +100,10 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 
 	ginkgo.Context("[release] with cluster configured", func() {
 		ginkgo.It("should have Node as Owner Reference", func() {
+			if !hasNodeRef {
+				ginkgo.Skip("node reference disabled")
+			}
+
 			ginkgo.By("getting the initial topology information")
 			expectedOwnerReference := metav1.OwnerReference{
 				Name:       topologyUpdaterNode.Name,

--- a/test/e2e/utils/testenv/testenv.go
+++ b/test/e2e/utils/testenv/testenv.go
@@ -18,6 +18,7 @@ package testenv
 
 import (
 	"os"
+	"strconv"
 )
 
 const (
@@ -30,6 +31,7 @@ const (
 	RTELabelName                = "resource-topology"
 	RTEContainerName            = "resource-topology-exporter-container"
 	DefaultDeviceName           = "example.com/deviceA"
+	DefaultNodeReferenceEnabled = false
 )
 
 var (
@@ -88,6 +90,15 @@ func GetDeviceName() string {
 		return devName
 	}
 	return DefaultDeviceName
+}
+
+func GetNodeReferenceEnabled() bool {
+	if nodeRef, ok := os.LookupEnv("E2E_NODE_REFERENCE"); ok {
+		if val, err := strconv.ParseBool(nodeRef); err == nil {
+			return val
+		}
+	}
+	return DefaultNodeReferenceEnabled
 }
 
 func SetNodeName(nodeName string) {


### PR DESCRIPTION
in order to make it easy to integrate the e2e test with other suites, let the nodeRef test to be conditionally skipped.