### PR TITLE
golangci-lint add developer config and related fixes

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,36 @@
+run:
+  timeout: 5m
+  tests: false
+  skip-dirs:
+    - vendor
+    - test
+  modules-download-mode: vendor
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - bodyclose
+    - exportloopref
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nolintlint
+    - nosprintfhostport
+    - staticcheck
+    - tenv
+    - typecheck
+    - unconvert
+    - unused
+    - wastedassign
+    - whitespace
+linters-settings:
+  misspell:
+    locale: US
+    ignore-words:
+      - NRO
+      - nro
+      - numaresource
+      - numa
+      - NUMA
+

--- a/pkg/k8shelpers/k8shelpers.go
+++ b/pkg/k8shelpers/k8shelpers.go
@@ -44,5 +44,4 @@ func GetK8sClient(kubeConfig string) (*kubernetes.Clientset, error) {
 	}
 
 	return kubernetes.NewForConfig(config)
-
 }

--- a/pkg/kubeconf/kubelet_config_file.go
+++ b/pkg/kubeconf/kubelet_config_file.go
@@ -1,7 +1,7 @@
 package kubeconf
 
 import (
-	"io/ioutil"
+	"os"
 
 	"sigs.k8s.io/yaml"
 
@@ -10,7 +10,7 @@ import (
 
 // GetKubeletConfigFromLocalFile returns KubeletConfiguration loaded from the node local config
 func GetKubeletConfigFromLocalFile(kubeletConfigPath string) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
-	kubeletBytes, err := ioutil.ReadFile(kubeletConfigPath)
+	kubeletBytes, err := os.ReadFile(kubeletConfigPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/notification/notification.go
+++ b/pkg/notification/notification.go
@@ -10,12 +10,6 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const (
-	stateCPUManager    string = "cpu_manager_state"
-	stateMemoryManager string = "memory_manager_state"
-	stateDeviceManager string = "kubelet_internal_checkpoint"
-)
-
 // FilterEvent returns true if the given event is relevant and should be handled
 type FilterEvent func(event fsnotify.Event) bool
 

--- a/pkg/nrtupdater/fake/fake.go
+++ b/pkg/nrtupdater/fake/fake.go
@@ -16,34 +16,34 @@ type Generator struct {
 	Infos    <-chan nrtupdater.MonitorInfo
 	infoChan chan nrtupdater.MonitorInfo
 	interval time.Duration
+	rnd      *rand.Rand
 }
 
-func NewGenerator(interval time.Duration) *Generator {
+func NewGenerator(interval time.Duration, randSeed int64) *Generator {
 	gen := Generator{
 		infoChan: make(chan nrtupdater.MonitorInfo),
 		interval: interval,
 	}
 	gen.Infos = gen.infoChan
+	gen.rnd = rand.New(rand.NewSource(randSeed))
 	return &gen
 }
 
 func (ge *Generator) Run() {
 	ticker := time.NewTicker(ge.interval)
 
-	for {
-		select {
-		case <-ticker.C:
-			mi := nrtupdater.MonitorInfo{
-				Timer: true,
-				Zones: Zones(),
-			}
-			ge.infoChan <- mi
-			klog.V(5).Infof("generated periodic update: %v", dump.Object(mi.Zones))
+	// TODO: move to for { select {} } when we have more sources
+	for range ticker.C {
+		mi := nrtupdater.MonitorInfo{
+			Timer: true,
+			Zones: ge.MakeZones(),
 		}
+		ge.infoChan <- mi
+		klog.V(5).Infof("generated periodic update: %v", dump.Object(mi.Zones))
 	}
 }
 
-func Zones() v1alpha2.ZoneList {
+func (ge *Generator) MakeZones() v1alpha2.ZoneList {
 	zones := v1alpha2.ZoneList{
 		v1alpha2.Zone{
 			Name: "fake-node-0",
@@ -59,8 +59,8 @@ func Zones() v1alpha2.ZoneList {
 				},
 			},
 			Resources: []v1alpha2.ResourceInfo{
-				ResourceInfoCPUs(128, 126, 126),
-				ResourceInfoDevices(16),
+				ge.MakeResourceInfoCPUs(128, 126, 126),
+				ge.MakeResourceInfoDevices(16),
 			},
 		},
 		v1alpha2.Zone{
@@ -77,28 +77,28 @@ func Zones() v1alpha2.ZoneList {
 				},
 			},
 			Resources: []v1alpha2.ResourceInfo{
-				ResourceInfoCPUs(128, 126, 126),
-				ResourceInfoDevices(16),
+				ge.MakeResourceInfoCPUs(128, 126, 126),
+				ge.MakeResourceInfoDevices(16),
 			},
 		},
 	}
 	return zones
 }
 
-func ResourceInfoDevices(count int) v1alpha2.ResourceInfo {
+func (ge *Generator) MakeResourceInfoDevices(count int) v1alpha2.ResourceInfo {
 	return v1alpha2.ResourceInfo{
 		Name:        "vendor.com/device",
 		Capacity:    *resource.NewQuantity(16, resource.DecimalSI),
 		Allocatable: *resource.NewQuantity(16, resource.DecimalSI),
-		Available:   *resource.NewQuantity(int64(rand.Intn(17)), resource.DecimalSI),
+		Available:   *resource.NewQuantity(int64(ge.rnd.Intn(17)), resource.DecimalSI),
 	}
 }
 
-func ResourceInfoCPUs(capacity, allocatable, available int) v1alpha2.ResourceInfo {
+func (ge *Generator) MakeResourceInfoCPUs(capacity, allocatable, available int) v1alpha2.ResourceInfo {
 	return v1alpha2.ResourceInfo{
 		Name:        "cpu",
 		Capacity:    *resource.NewQuantity(int64(capacity), resource.DecimalSI),
 		Allocatable: *resource.NewQuantity(int64(allocatable), resource.DecimalSI),
-		Available:   *resource.NewQuantity(int64(rand.Intn(available+1)), resource.DecimalSI),
+		Available:   *resource.NewQuantity(int64(ge.rnd.Intn(available+1)), resource.DecimalSI),
 	}
 }

--- a/pkg/ratelimiter/ratelimiter.go
+++ b/pkg/ratelimiter/ratelimiter.go
@@ -27,7 +27,7 @@ const bufferSize uint16 = 5
 
 // The ratelimiter is a kind of man-in-the-middle.
 // It provides an input interface with a channel for a writter to send events at any rate
-// and an ouput interface with another channel where a reader will receive events at a configured rate
+// and an output interface with another channel where a reader will receive events at a configured rate
 // At the input interface the main goals are:
 // - writer should not block at all or tha minimum time possible.
 // - If there is no more room for events in the "bucket" the write should not block at all but "fail" silently.
@@ -46,7 +46,6 @@ type RateLimitedEventSource struct {
 }
 
 func NewRateLimitedEventSource(es notification.EventSource, maxEventsPerTimeUnit uint64, timeUnit time.Duration) (*RateLimitedEventSource, error) {
-
 	rles := RateLimitedEventSource{
 		es:       es,
 		inCh:     es.Events(),
@@ -93,7 +92,7 @@ func (rles *RateLimitedEventSource) Close() {
 }
 
 // run launch two different goroutines to avoid decorated event source
-// to block on writting an event while the other one delivers events
+// to block on writing an event while the other one delivers events
 // at the configured rate.
 // see: receiver and sender functions for more info
 func (rles *RateLimitedEventSource) run() {
@@ -133,7 +132,6 @@ func (rles *RateLimitedEventSource) sender() {
 			return
 		}
 	}
-
 }
 
 // wait stops the caller until the EventSource is exhausted

--- a/pkg/resourcemonitor/resourcemonitor.go
+++ b/pkg/resourcemonitor/resourcemonitor.go
@@ -103,10 +103,10 @@ type ResourceMonitor interface {
 }
 
 // ToMapSet keeps the original keys, but replaces values with set.String types
-func (rel ResourceExclude) ToMapSet() map[string]sets.String {
-	asSet := make(map[string]sets.String)
+func (rel ResourceExclude) ToMapSet() map[string]sets.Set[string] {
+	asSet := make(map[string]sets.Set[string])
 	for k, v := range rel {
-		asSet[k] = sets.NewString(v...)
+		asSet[k] = sets.New[string](v...)
 	}
 	return asSet
 }
@@ -424,7 +424,6 @@ func GetAllContainerDevices(podRes []*podresourcesapi.PodResources, namespace st
 		for _, cnt := range pr.GetContainers() {
 			allCntRes = append(allCntRes, NormalizeContainerDevices(cnt.GetDevices(), cnt.GetMemory(), cnt.GetCpuIds(), coreIDToNodeIDMap)...)
 		}
-
 	}
 	return allCntRes
 }
@@ -557,7 +556,7 @@ func findNodeByID(nodes []*ghw.TopologyNode, nodeID int) *ghw.TopologyNode {
 	return nil
 }
 
-func inExcludeSet(excludeSet map[string]sets.String, resName v1.ResourceName, nodeName string) bool {
+func inExcludeSet(excludeSet map[string]sets.Set[string], resName v1.ResourceName, nodeName string) bool {
 	if set, ok := excludeSet["*"]; ok && set.Has(string(resName)) {
 		return true
 	}

--- a/pkg/sysinfo/hugepages.go
+++ b/pkg/sysinfo/hugepages.go
@@ -16,7 +16,7 @@ package sysinfo
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -35,7 +35,7 @@ type Hugepages struct {
 type PerNUMACounters map[int]int64
 
 func GetHugepages(hnd Handle) ([]*Hugepages, error) {
-	entries, err := ioutil.ReadDir(hnd.SysDevicesNodes())
+	entries, err := os.ReadDir(hnd.SysDevicesNodes())
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +67,7 @@ func HugepagesForNode(hnd Handle, nodeID int) ([]*Hugepages, error) {
 	)
 	hugepages := []*Hugepages{}
 
-	entries, err := ioutil.ReadDir(path)
+	entries, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func HugepagesForNode(hnd Handle, nodeID int) ([]*Hugepages, error) {
 }
 
 func readIntFromFile(path string) (int, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return -1, err
 	}

--- a/pkg/sysinfo/memory.go
+++ b/pkg/sysinfo/memory.go
@@ -14,7 +14,7 @@ package sysinfo
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -23,7 +23,7 @@ import (
 )
 
 func GetMemory(hnd Handle) (map[int]int64, error) {
-	entries, err := ioutil.ReadDir(hnd.SysDevicesNodes())
+	entries, err := os.ReadDir(hnd.SysDevicesNodes())
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func MemoryForNode(hnd Handle, nodeID int) (int64, error) {
 }
 
 func readTotalMemoryFromMeminfo(path string) (int64, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return -1, err
 	}

--- a/tools/nrtstress/main.go
+++ b/tools/nrtstress/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"math/rand"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -38,13 +37,9 @@ func main() {
 		randSeed = int64(seed)
 	}
 
-	klog.Infof("seed: %v", randSeed)
+	klog.Infof("generating fake periodic updates every %v with random seed %v", interval, randSeed)
 
-	rand.Seed(randSeed)
-
-	klog.Infof("generating fake periodic updates every %v", interval)
-
-	gen := fake.NewGenerator(interval)
+	gen := fake.NewGenerator(interval, randSeed)
 	go gen.Run()
 
 	klog.Infof("using NRT Updater args: %+#v", nrtupdaterArgs)


### PR DESCRIPTION
Add new makefile target to run golangci-lint and to be used by developers.
Later (soonish) we will integrate golangci-lint in CI using the recommended GH action.

This PR also includes a batch of related fixes for the issues raised by the golangci-lint run.