### PR TITLE
gh actions: enable e2e on release-0.11

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - 'main'
+      - 'release-0.11'
 
 defaults:
   run:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - 'main'
+      - 'release-0.11'
 
 jobs:
 


### PR DESCRIPTION
we're promoting release-0.11 to LTS - because we want to support users stuck on 1.25. So enable CI on that branch.