### PR TITLE
[release-0.16][manual] sysinfo: hugepages: stricter checks, louder error handling 

### DIFF
--- a/pkg/sysinfo/hugepages.go
+++ b/pkg/sysinfo/hugepages.go
@@ -34,13 +34,13 @@ type Hugepages struct {
 
 type PerNUMACounters map[int]int64
 
-func GetHugepages(hnd Handle) ([]*Hugepages, error) {
+func GetHugepages(hnd Handle) ([]Hugepages, error) {
 	entries, err := os.ReadDir(hnd.SysDevicesNodes())
 	if err != nil {
 		return nil, err
 	}
 
-	hugepages := []*Hugepages{}
+	hugepages := []Hugepages{}
 	for _, entry := range entries {
 		entryName := entry.Name()
 		if entry.IsDir() && strings.HasPrefix(entryName, "node") {
@@ -60,20 +60,21 @@ func GetHugepages(hnd Handle) ([]*Hugepages, error) {
 	return hugepages, nil
 }
 
-func HugepagesForNode(hnd Handle, nodeID int) ([]*Hugepages, error) {
-	path := filepath.Join(
+func HugepagesForNode(hnd Handle, nodeID int) ([]Hugepages, error) {
+	hpPath := filepath.Join(
 		hnd.SysDevicesNodesNodeNth(nodeID),
 		"hugepages",
 	)
-	hugepages := []*Hugepages{}
+	hugepages := []Hugepages{}
 
-	entries, err := os.ReadDir(path)
+	entries, err := os.ReadDir(hpPath)
 	if err != nil {
 		return nil, err
 	}
 	for _, entry := range entries {
 		entryName := entry.Name()
-		entryPath := filepath.Join(path, entryName)
+		entryPath := filepath.Join(hpPath, entryName)
+
 		var hugepageSizeKB int
 		if n, err := fmt.Sscanf(entryName, "hugepages-%dkB", &hugepageSizeKB); n != 1 || err != nil {
 			klog.Warningf("malformed hugepages entry %q", entryName)
@@ -86,7 +87,7 @@ func HugepagesForNode(hnd Handle, nodeID int) ([]*Hugepages, error) {
 			continue
 		}
 
-		hugepages = append(hugepages, &Hugepages{
+		hugepages = append(hugepages, Hugepages{
 			NodeID: nodeID,
 			SizeKB: hugepageSizeKB,
 			Total:  totalCount,

--- a/pkg/sysinfo/hugepages_test.go
+++ b/pkg/sysinfo/hugepages_test.go
@@ -65,7 +65,7 @@ func TestHugepagesForNode(t *testing.T) {
 	}
 	defer os.RemoveAll(rootDir) // clean up
 
-	if err := makeTree(rootDir, 2); err != nil {
+	if err := makeMemoryTree(rootDir, 2); err != nil {
 		t.Errorf("failed to setup the fake tree on %q: %v", rootDir, err)
 	}
 	if err := setHPCount(rootDir, 0, HugepageSize2Mi, 6); err != nil {
@@ -92,32 +92,12 @@ func TestHugepagesForNode(t *testing.T) {
 	if len(hpCounters["hugepages-1Gi"]) != 2 {
 		t.Errorf("found unexpected 1Gi hugepages")
 	}
-	if hpCounters["hugepages-1Gi"][0] != 0 {
+	if hpCounters["hugepages-1Gi"][0] != 17179869184 { // from makeMemoryTree builtin
 		t.Errorf("found unexpected 1Gi hugepages for node 0: %v", hpCounters["hugepages-1Gi"][0])
 	}
-	if hpCounters["hugepages-1Gi"][1] != 0 {
+	if hpCounters["hugepages-1Gi"][1] != 17179869184 { // from makeMemoryTree builtin
 		t.Errorf("found unexpected 1Gi hugepages for node 1: %v", hpCounters["hugepages-1Gi"][1])
 	}
-}
-
-func makeTree(root string, numNodes int) error {
-	hnd := Handle{root}
-	for idx := 0; idx < numNodes; idx++ {
-		for _, size := range []int{HugepageSize2Mi, HugepageSize1Gi} {
-			path := filepath.Join(
-				hnd.SysDevicesNodesNodeNth(idx),
-				"hugepages",
-				fmt.Sprintf("hugepages-%dkB", size),
-			)
-			if err := os.MkdirAll(path, 0755); err != nil {
-				return err
-			}
-			if err := setHPCount(root, idx, size, 0); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 func setHPCount(root string, nodeID, pageSize, numPages int) error {

--- a/pkg/sysinfo/memory.go
+++ b/pkg/sysinfo/memory.go
@@ -18,8 +18,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-
-	"k8s.io/klog/v2"
 )
 
 func GetMemory(hnd Handle) (map[int]int64, error) {
@@ -34,13 +32,11 @@ func GetMemory(hnd Handle) (map[int]int64, error) {
 		if entry.IsDir() && strings.HasPrefix(entryName, "node") {
 			nodeID, err := strconv.Atoi(entryName[4:])
 			if err != nil {
-				klog.Warningf("cannot detect the node ID for %q", entryName)
-				continue
+				return memory, fmt.Errorf("cannot detect the node ID for %q", entryName)
 			}
 			nodeMemory, err := MemoryForNode(hnd, nodeID)
 			if err != nil {
-				klog.Warningf("cannot find the memory on NUMA node %d: %v", nodeID, err)
-				continue
+				return memory, fmt.Errorf("cannot find the memory on NUMA node %d: %w", nodeID, err)
 			}
 			memory[nodeID] = nodeMemory
 		}

--- a/pkg/sysinfo/memory_test.go
+++ b/pkg/sysinfo/memory_test.go
@@ -91,6 +91,20 @@ func makeMemoryTree(root string, numNodes int) error {
 			return err
 		}
 
+		hpPathSizes := []string{"hugepages-1048576kB", "hugepages-2048kB"}
+		for _, hpPathSize := range hpPathSizes {
+			hpPath := filepath.Join(
+				hnd.SysDevicesNodesNodeNth(idx),
+				"hugepages",
+				hpPathSize,
+			)
+			if err := os.MkdirAll(hpPath, 0755); err != nil {
+				return err
+			}
+			if err := os.WriteFile(filepath.Join(hpPath, "nr_hugepages"), []byte("16"), 0644); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/sysinfo/memory_test.go
+++ b/pkg/sysinfo/memory_test.go
@@ -13,6 +13,7 @@ limitations under the License.
 package sysinfo
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -91,12 +92,11 @@ func makeMemoryTree(root string, numNodes int) error {
 			return err
 		}
 
-		hpPathSizes := []string{"hugepages-1048576kB", "hugepages-2048kB"}
-		for _, hpPathSize := range hpPathSizes {
+		for _, size := range []int{HugepageSize2Mi, HugepageSize1Gi} {
 			hpPath := filepath.Join(
 				hnd.SysDevicesNodesNodeNth(idx),
 				"hugepages",
-				hpPathSize,
+				fmt.Sprintf("hugepages-%dkB", size),
 			)
 			if err := os.MkdirAll(hpPath, 0755); err != nil {
 				return err


### PR DESCRIPTION
Add more validations when checking for hugepages, reducing the chance to read random junk in the system.
The layout of sysfs is stable and guaranteed; thus, should we encounter errors navigating it, we should
make sure to make noise and bubble them up, because it means something really weird happened.