### PR TITLE
manifests: ci: switch to config files

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,13 +14,12 @@ jobs:
   e2e-ic:
     runs-on: ubuntu-22.04
     env:
-      # TODO
-      RTE_CONTAINER_IMAGE: quay.io/k8stopologyawarewg/resource-topology-exporter:ci
+      E2E_NODE_REFERENCE: true
       E2E_TOPOLOGY_MANAGER_POLICY: single-numa-node
       E2E_TOPOLOGY_MANAGER_SCOPE: container
-      E2E_NODE_REFERENCE: true
+      RTE_CONTAINER_IMAGE: quay.io/k8stopologyawarewg/resource-topology-exporter:ci
       RTE_POLL_INTERVAL: 10s
-      RTE_VERBOSE: 6
+      RTE_VERBOSE: 4
     steps:
     - name: checkout sources
       uses: actions/checkout@v3

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -4,6 +4,7 @@ RUN cd /etc/yum.repos.d/ && \
 	sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 RUN yum install -y hwdata && yum clean -y all
 ADD _out/resource-topology-exporter /bin/resource-topology-exporter
+RUN mkdir -p /etc/rte
 
 ARG GIT_COMMIT
 ARG VERSION

--- a/manifests/resource-topology-exporter-config.yaml
+++ b/manifests/resource-topology-exporter-config.yaml
@@ -6,14 +6,27 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: rte-config
+  name: rte-config-extra
   namespace: default
 data:
   config.yaml: |
-    # key = node name, value = list of resources to be excluded.
-    # use * to exclude from all nodes.
-    # an example for how the exclude list should looks like
-    # excludelist:
-    #   node1: [cpu]
-    #   node2: [memory, example/deviceA]
-    #   *: [cpu]
+    kubelet:
+      topologyManagerPolicy: single-numa-node
+      topologyManagerScope: container
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rte-config-daemon
+  namespace: default
+data:
+  config.yaml: |
+    global:
+      verbose: 6
+      debug: true
+    resourceMonitor:
+      exposeTiming: true
+      refreshNodeResources: true
+    topologyExporter:
+      addNRTOwnerEnable: true
+      podReadinessEnable: true

--- a/manifests/resource-topology-exporter-ds-notif-file.yaml
+++ b/manifests/resource-topology-exporter-ds-notif-file.yaml
@@ -19,7 +19,6 @@ spec:
         command:
         - /bin/resource-topology-exporter
         args:
-          - -v=5
           - --sleep-interval=${RTE_POLL_INTERVAL}
           - --sysfs=/host-sys
           - --notify-file=/host-run/rte/notify
@@ -51,8 +50,8 @@ spec:
             mountPath: "/host-podresources"
           - name: host-rte-notification
             mountPath: "/host-run/rte"
-          - name: rte-config
-            mountPath: "/etc/resource-topology-exporter"
+          - name: rte-config-extra
+            mountPath: "/etc/rte/extra"
         ports:
           - name: metrics-port
             containerPort: ${METRICS_PORT}

--- a/manifests/resource-topology-exporter.yaml
+++ b/manifests/resource-topology-exporter.yaml
@@ -38,17 +38,30 @@ roleRef:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: rte-config
+  name: rte-config-extra
   namespace: default
 data:
   config.yaml: |
-    # key = node name, value = list of resources to be excluded.
-    # use * to exclude from all nodes.
-    # an example for how the exclude list should looks like
-    # excludelist:
-    #   node1: [cpu]
-    #   node2: [memory, example/deviceA]
-    #   *: [cpu]
+    kubelet:
+      topologyManagerPolicy: single-numa-node
+      topologyManagerScope: container
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rte-config-daemon
+  namespace: default
+data:
+  config.yaml: |
+    global:
+      verbose: ${RTE_VERBOSE}
+      debug: true
+    resourceMonitor:
+      exposeTiming: true
+      refreshNodeResources: true
+    topologyExporter:
+      addNRTOwnerEnable: true
+      podReadinessEnable: true
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -73,15 +86,12 @@ spec:
         command:
         - /bin/resource-topology-exporter
         args:
-          - -v=${RTE_VERBOSE}
+          - --dump-config=.log
           - --sleep-interval=${RTE_POLL_INTERVAL}
           - --sysfs=/host-sys
           - --kubelet-config-file=/host-var/lib/kubelet/config.yaml
           - --podresources-socket=unix:///host-var/lib/kubelet/pod-resources/kubelet.sock
           - --notify-file=/host-run/rte/notify
-          - --pods-fingerprint
-          - --expose-timing
-          - --refresh-node-resources
         env:
         - name: NODE_NAME
           valueFrom:
@@ -105,8 +115,10 @@ spec:
             readOnly: true
           - name: host-kubelet-state
             mountPath: "/host-var/lib/kubelet"
-          - name: exclude-list-config-vol
-            mountPath: "/etc/resource-topology-exporter"
+          - name: rte-config-daemon
+            mountPath: "/etc/rte/daemon"
+          - name: rte-config-extra
+            mountPath: "/etc/rte/extra"
           - name: host-rte-notification
             mountPath: "/host-run/rte"
         ports:
@@ -121,10 +133,12 @@ spec:
       - name: host-kubelet-state
         hostPath:
           path: "/var/lib/kubelet"
-      - name: exclude-list-config-vol
+      - name: rte-config-daemon
         configMap:
-          name: resource-topology-exporter-config
-          optional: true
+          name: rte-config-daemon
+      - name: rte-config-extra
+        configMap:
+          name: rte-config-extra
       - name: host-rte-notification
         hostPath:
           path: "/run/rte"

--- a/pkg/resourcemonitor/resourcemonitor.go
+++ b/pkg/resourcemonitor/resourcemonitor.go
@@ -189,16 +189,13 @@ func NewResourceMonitor(hnd Handle, args Args, options ...func(*resourceMonitor)
 
 	rm.coreIDToNodeIDMap = MakeCoreIDToNodeIDMap(rm.topo)
 
+	if err := rm.updateNodeResources(); err != nil {
+		return nil, err
+	}
 	if !rm.args.RefreshNodeResources {
 		klog.Infof("getting node resources once")
-		if err := rm.updateNodeResources(); err != nil {
-			return nil, err
-		}
 	} else {
 		klog.Infof("tracking node resources")
-		if err := rm.updateNodeResources(); err != nil {
-			return nil, err
-		}
 		if err := addNodeInformerEvent(rm.k8sCli, cache.ResourceEventHandlerFuncs{UpdateFunc: rm.resUpdated}); err != nil {
 			return nil, err
 		}

--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -299,8 +299,8 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 				logs, err := e2epods.GetLogsForPod(f.K8SCli, rtePod.Namespace, rtePod.Name, rteContainerName)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-				return strings.Contains(logs, "update node resources")
-			}).WithTimeout(30*time.Second).WithPolling(10*time.Second).Should(gomega.BeTrue(), "container: %q in pod: %q doesn't contains the refresh log message", rteContainerName, rtePod.Name)
+				return strings.Contains(logs, "tracking node resources") || strings.Contains(logs, "update node resources")
+			}).WithTimeout(42*time.Second).WithPolling(5*time.Second).Should(gomega.BeTrue(), "container: %q in pod: %q doesn't contains the refresh log message", rteContainerName, rtePod.Name)
 		})
 	})
 })


### PR DESCRIPTION
we want to setup TLS in CI, and doing it using config files is the preferred way. So let's start moving the existing config towards config files.