### PR TITLE
Increase timeout to allow enough time for ds pod creation

### DIFF
--- a/hack/check-ds.sh
+++ b/hack/check-ds.sh
@@ -6,7 +6,7 @@ DAEMONSET="${2:-resource-topology-exporter-ds}"
 FAILED=1
 
 function wait-for-daemonset(){
-    retries=24
+    retries=60
     while [[ $retries -ge 0 ]];do
         sleep 5
         ready=$(kubectl -n $NAMESPACE get daemonset $DAEMONSET -o jsonpath="{.status.numberReady}")


### PR DESCRIPTION
There can be scenarios where Daemon set has been successfully created but the pods haven't.

We increase the retry attempts to give more time for the corresponding pods under the RTE daemonset to be created.

Rather than waiting for 2 minutes (24 attempts every 5 secs), we wait for 5 minutes (60 attempts every 5 secs).