### PR TITLE
[release-0.16][manual] Limit serving of insecure metrics by allowing configurable IP

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -91,3 +91,89 @@ jobs:
       if: ${{ failure() }}
       run: |
         kubectl logs -l name=resource-topology -c resource-topology-exporter-container || :
+
+  e2e-metrics:
+    strategy:
+      matrix:
+        mode: [http, httptls]
+        address: ["0.0.0.0","127.120.110.100"]
+    runs-on: ubuntu-22.04
+    env:
+      E2E_NODE_REFERENCE: true
+      E2E_TOPOLOGY_MANAGER_POLICY: single-numa-node
+      E2E_TOPOLOGY_MANAGER_SCOPE: container
+      RTE_CONTAINER_IMAGE: quay.io/k8stopologyawarewg/resource-topology-exporter:ci
+      RTE_METRICS_CLI_AUTH: false
+      RTE_METRICS_MODE: ${{ matrix.mode }}
+      METRICS_ADDRESS: ${{ matrix.address }}
+      METRICS_PORT: "2112"
+      RTE_POLL_INTERVAL: 10s
+      RTE_VERBOSE: 6
+    steps:
+    - name: checkout sources
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: setup golang
+      uses: actions/setup-go@v3
+      id: go
+      with:
+        go-version: 1.20.7
+
+    - name: show tool versions
+      run: |
+        go version
+        kind version
+
+    - name: build test binary
+      run: |
+        make build-e2e
+
+    - name: build image
+      run: |
+        RTE_CONTAINER_IMAGE=${RTE_CONTAINER_IMAGE} RUNTIME=docker make image
+
+    - name: generate manifests
+      run: |
+        RTE_CONTAINER_IMAGE=${RTE_CONTAINER_IMAGE} \
+        RTE_METRICS_MODE=${RTE_METRICS_MODE} \
+        METRICS_ADDRESS=${METRICS_ADDRESS} \
+        METRICS_PORT=${METRICS_PORT} \
+        RTE_POLL_INTERVAL=${RTE_POLL_INTERVAL} \
+        RTE_VERBOSE=${RTE_VERBOSE} \
+        make gen-manifests | tee rte-e2e.yaml
+
+    - name: create K8S kind cluster
+      run: |
+        # kind is part of 20.04 image, see: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
+        # see image listing in https://github.com/kubernetes-sigs/kind/releases/tag/v0.20.0
+        kind create cluster --config=hack/kind-config-e2e.yaml --image kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
+        kind load docker-image ${RTE_CONTAINER_IMAGE}
+
+    - name: deploy RTE
+      run: |
+        # TODO: what about the other workers (if any)?
+        kubectl label node kind-worker node-role.kubernetes.io/worker=''
+        hack/create-tls-secrets.sh
+        kubectl create -f rte-e2e.yaml
+
+    - name: cluster ready
+      run: |
+        hack/check-ds.sh
+
+    - name: deploy sample-devices
+      run: |
+        hack/deploy-devices.sh
+        hack/check-ds.sh default device-plugin-a-ds
+        kubectl describe nodes -l node-role.kubernetes.io/worker= || :
+
+    - name: run E2E tests
+      run: |
+        export KUBECONFIG=${HOME}/.kube/config
+        _out/rte-e2e.test -ginkgo.v -ginkgo.focus='\[RTE\].*\[Monitoring\]'
+
+    - name: show RTE logs
+      if: ${{ failure() }}
+      run: |
+        kubectl logs -l name=resource-topology -c resource-topology-exporter-container || :

--- a/hack/get-manifests.sh
+++ b/hack/get-manifests.sh
@@ -9,4 +9,5 @@ export RTE_CONTAINER_IMAGE=${RTE_CONTAINER_IMAGE:-quay.io/${REPOOWNER}/${IMAGENA
 export RTE_POLL_INTERVAL="${RTE_POLL_INTERVAL:-60s}"
 export RTE_VERBOSE="${RTE_VERBOSE:-5}"
 export METRICS_PORT="${METRICS_PORT:-2112}"
+export METRICS_ADDRESS="${METRICS_ADDRESS:-127.0.0.1}"
 envsubst < ${DIRNAME}/../manifests/resource-topology-exporter.yaml

--- a/manifests/resource-topology-exporter-ds-notif-file.yaml
+++ b/manifests/resource-topology-exporter-ds-notif-file.yaml
@@ -43,6 +43,8 @@ spec:
           value: shared-pool-container
         - name: METRICS_PORT
           value: "${METRICS_PORT}"
+        - name: METRICS_ADDRESS
+          value: "${METRICS_ADDRESS}"
         volumeMounts:
           - name: host-sys
             mountPath: "/host-sys"

--- a/manifests/resource-topology-exporter.yaml
+++ b/manifests/resource-topology-exporter.yaml
@@ -99,6 +99,8 @@ spec:
           value: shared-pool-container
         - name: METRICS_PORT
           value: "${METRICS_PORT}"
+        - name: METRICS_ADDRESS
+          value: "${METRICS_ADDRESS}"
         volumeMounts:
           - name: host-sys
             mountPath: "/host-sys"

--- a/test/e2e/rte/metrics.go
+++ b/test/e2e/rte/metrics.go
@@ -119,7 +119,7 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 		ginkgo.It("[EventChain] should have some metrics exported", func() {
 			rteContainerName, err := e2ertepod.FindRTEContainerName(rtePod)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			cmd := []string{"curl", fmt.Sprintf("http://%s:%d/metrics", metricsAddress, metricsPort)}
+			cmd := []string{"curl", "-v", "-L", fmt.Sprintf("http://%s:%d/metrics", metricsAddress, metricsPort)}
 			key := client.ObjectKeyFromObject(rtePod)
 			klog.Infof("executing cmd: %s on pod %q", cmd, key.String())
 			var stdout, stderr []byte
@@ -150,7 +150,7 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 			rteContainerName, err := e2ertepod.FindRTEContainerName(rtePod)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			cmd := []string{"curl", fmt.Sprintf("http:%s:%d/metrics", metricsAddress, metricsPort)}
+			cmd := []string{"curl", "-v", "-L", fmt.Sprintf("http:%s:%d/metrics", metricsAddress, metricsPort)}
 			key := client.ObjectKeyFromObject(rtePod)
 			klog.Infof("executing cmd: %s on pod %q", cmd, key.String())
 			var stdout, stderr []byte

--- a/test/e2e/rte/metrics.go
+++ b/test/e2e/rte/metrics.go
@@ -52,6 +52,7 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 		hasMetrics          bool
 		rtePod              *corev1.Pod
 		metricsPort         int
+		metricsAddress      string
 		workerNodes         []corev1.Node
 		topologyUpdaterNode *corev1.Node
 	)
@@ -100,6 +101,8 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 			if hasMetrics {
 				metricsPort, err = e2ertepod.FindMetricsPort(rtePod)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				metricsAddress, err = e2ertepod.FindMetricsAddress(rtePod)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			}
 
 			initialized = true
@@ -116,7 +119,7 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 		ginkgo.It("[EventChain] should have some metrics exported", func() {
 			rteContainerName, err := e2ertepod.FindRTEContainerName(rtePod)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			cmd := []string{"curl", fmt.Sprintf("http://127.0.0.1:%d/metrics", metricsPort)}
+			cmd := []string{"curl", fmt.Sprintf("http://%s:%d/metrics", metricsAddress, metricsPort)}
 			key := client.ObjectKeyFromObject(rtePod)
 			klog.Infof("executing cmd: %s on pod %q", cmd, key.String())
 			var stdout, stderr []byte
@@ -147,7 +150,7 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 			rteContainerName, err := e2ertepod.FindRTEContainerName(rtePod)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			cmd := []string{"curl", fmt.Sprintf("http://127.0.0.1:%d/metrics", metricsPort)}
+			cmd := []string{"curl", fmt.Sprintf("http:%s:%d/metrics", metricsAddress, metricsPort)}
 			key := client.ObjectKeyFromObject(rtePod)
 			klog.Infof("executing cmd: %s on pod %q", cmd, key.String())
 			var stdout, stderr []byte

--- a/test/e2e/utils/pods/rtepod/rtepod.go
+++ b/test/e2e/utils/pods/rtepod/rtepod.go
@@ -51,6 +51,22 @@ func FindMetricsPort(rtePod *corev1.Pod) (int, error) {
 	return 0, fmt.Errorf("cannot find METRICS_PORT environment variable")
 }
 
+func FindMetricsAddress(rtePod *corev1.Pod) (string, error) {
+	for idx := 0; idx < len(rtePod.Spec.Containers); idx++ {
+		cnt := rtePod.Spec.Containers[idx] // shortcut
+		if !isRTEContainer(cnt) {
+			continue
+		}
+
+		for _, envVar := range cnt.Env {
+			if envVar.Name == "METRICS_ADDRESS" {
+				return envVar.Value, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("cannot find METRICS_ADDRESS environment variable")
+}
+
 func FindRTEContainerName(rtePod *corev1.Pod) (string, error) {
 	for idx := 0; idx < len(rtePod.Spec.Containers); idx++ {
 		cnt := rtePod.Spec.Containers[idx] // shortcut


### PR DESCRIPTION
This is a reimplementation of https://github.com/k8stopologyawareschedwg/resource-topology-exporter/pull/275 and https://github.com/k8stopologyawareschedwg/resource-topology-exporter/pull/280 on 0.16 branch to achieve the same end to end behavior.

Currently we are serving insecure metrics on all IPv4 routable addresses on the local machine (0.0.0.0).

In this PR, we make the metric IP configurable in order to ensure that we listen for insecure metrics port only on one IP to reduce security vulnerability.