### PR TITLE
[release-0.17][manual]Add test cases for explicit Metric Address to be executed in CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -96,14 +96,21 @@ jobs:
       run: |
         kubectl logs -l name=resource-topology -c resource-topology-exporter-container || :
 
-  e2e-metrics-https:
+  e2e-metrics:
+    strategy:
+      matrix:
+        mode: [http, httptls]
+        address: ["0.0.0.0","127.120.110.100"]
     runs-on: ubuntu-22.04
     env:
       E2E_NODE_REFERENCE: true
       E2E_TOPOLOGY_MANAGER_POLICY: single-numa-node
       E2E_TOPOLOGY_MANAGER_SCOPE: container
       RTE_CONTAINER_IMAGE: quay.io/k8stopologyawarewg/resource-topology-exporter:ci
-      RTE_METRICS_MODE: httptls
+      RTE_METRICS_CLI_AUTH: false
+      RTE_METRICS_MODE: ${{ matrix.mode }}
+      METRICS_ADDRESS: ${{ matrix.address }}
+      METRICS_PORT: "2112"
       RTE_POLL_INTERVAL: 10s
       RTE_VERBOSE: 6
     steps:
@@ -135,6 +142,8 @@ jobs:
       run: |
         RTE_CONTAINER_IMAGE=${RTE_CONTAINER_IMAGE} \
         RTE_METRICS_MODE=${RTE_METRICS_MODE} \
+        METRICS_ADDRESS=${METRICS_ADDRESS} \
+        METRICS_PORT=${METRICS_PORT} \
         RTE_POLL_INTERVAL=${RTE_POLL_INTERVAL} \
         RTE_VERBOSE=${RTE_VERBOSE} \
         make gen-manifests | tee rte-e2e.yaml

--- a/test/e2e/rte/metrics.go
+++ b/test/e2e/rte/metrics.go
@@ -52,7 +52,7 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 		hasMetrics          bool
 		metricsMode         string
 		metricsPort         int
-		MetricsAddress      string
+		metricsAddress      string
 		rtePod              *corev1.Pod
 		workerNodes         []corev1.Node
 		topologyUpdaterNode *corev1.Node
@@ -100,7 +100,7 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 			rtePod = &pods.Items[0]
 
 			if hasMetrics {
-				MetricsAddress, err = e2ertepod.FindMetricsAddress(rtePod)
+				metricsAddress, err = e2ertepod.FindMetricsAddress(rtePod)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				metricsPort, err = e2ertepod.FindMetricsPort(rtePod)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -123,7 +123,7 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 			}
 			rteContainerName, err := e2ertepod.FindRTEContainerName(rtePod)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			cmd := []string{"curl", "-v", "-k", "-L", fmt.Sprintf("https://%s:%d/metrics", MetricsAddress, metricsPort)}
+			cmd := []string{"curl", "-v", "-k", "-L", fmt.Sprintf("https://%s:%d/metrics", metricsAddress, metricsPort)}
 			key := client.ObjectKeyFromObject(rtePod)
 			klog.Infof("executing cmd: %s on pod %q", cmd, key.String())
 			var stdout, stderr []byte
@@ -142,7 +142,7 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 			}
 			rteContainerName, err := e2ertepod.FindRTEContainerName(rtePod)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			cmd := []string{"curl", "-v", "-L", fmt.Sprintf("http://%s:%d/metrics", MetricsAddress, metricsPort)}
+			cmd := []string{"curl", "-v", "-L", fmt.Sprintf("http://%s:%d/metrics", metricsAddress, metricsPort)}
 			key := client.ObjectKeyFromObject(rtePod)
 			klog.Infof("executing cmd: %s on pod %q", cmd, key.String())
 			var stdout, stderr []byte
@@ -176,7 +176,7 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 			rteContainerName, err := e2ertepod.FindRTEContainerName(rtePod)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			cmd := []string{"curl", "-v", "-L", fmt.Sprintf("http://%s:%d/metrics", MetricsAddress, metricsPort)}
+			cmd := []string{"curl", "-v", "-L", fmt.Sprintf("http://%s:%d/metrics", metricsAddress, metricsPort)}
 			key := client.ObjectKeyFromObject(rtePod)
 			klog.Infof("executing cmd: %s on pod %q", cmd, key.String())
 			var stdout, stderr []byte


### PR DESCRIPTION
Backport of https://github.com/k8stopologyawareschedwg/resource-topology-exporter/pull/280 on release-0.17 branch.

Since it is assumed that the RTE pod is created prior to execution of the e2e tests, we add additional CI lanes to tackle cases where Metric Address and port is explicitly specified. We add two cases, one where the metric mode is http and another one where httptls.