### PR TITLE
ghactions: more rte logs on error

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -96,7 +96,7 @@ jobs:
     - name: show RTE logs
       if: ${{ failure() }}
       run: |
-        kubectl logs -l name=resource-topology -c resource-topology-exporter-container || :
+        kubectl logs -c resource-topology-exporter-container $( kubectl get pods --no-headers -o custom-columns=":metadata.name" | grep -- resource-topology-exporter ) || :
 
   e2e-metrics:
     strategy:
@@ -183,4 +183,4 @@ jobs:
     - name: show RTE logs
       if: ${{ failure() }}
       run: |
-        kubectl logs -l name=resource-topology -c resource-topology-exporter-container || :
+        kubectl logs -c resource-topology-exporter-container $( kubectl get pods --no-headers -o custom-columns=":metadata.name" | grep -- resource-topology-exporter ) || :


### PR DESCRIPTION
turns out that if we target a specific pod we get the full available logs, vs a reduced log amount if we target by label

since in CI the RTE pod name is fairly predicatable and we have few pods, let's find (hackishly) the pod name and let's target it to get more context.