### PR TITLE
ghactions: bump upload-artifact to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
         pushd _dist && sha256sum * >> ../SHA256SUMS && mv ../SHA256SUMS . && popd
 
     - name: upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: build-artifacts
         path: _dist/*


### PR DESCRIPTION
Older versions will case the lane to auto-fail

Signed-off-by: Francesco Romani <fromani@redhat.com>
(cherry picked from commit 41aca66138d2a9eabcf1ffcd87d42c46690e70b3)