### PR TITLE
config: add path validation

### DIFF
--- a/pkg/config/cfgfile_test.go
+++ b/pkg/config/cfgfile_test.go
@@ -27,10 +27,10 @@ import (
 )
 
 func TestReadResourceExclude(t *testing.T) {
-	closer := setupTest(t)
+	testDir, closer := setupTest(t)
 	t.Cleanup(closer)
 
-	cfg, err := os.CreateTemp("", "exclude-list")
+	cfg, err := os.CreateTemp(testDir, "exclude-list")
 	if err != nil {
 		t.Fatalf("unexpected error creating temp file: %v", err)
 	}
@@ -69,6 +69,9 @@ func TestReadResourceExclude(t *testing.T) {
 }
 
 func TestFromFiles(t *testing.T) {
+	testDir, closer := setupTest(t)
+	t.Cleanup(closer)
+
 	type testCase struct {
 		name string
 	}
@@ -79,7 +82,7 @@ func TestFromFiles(t *testing.T) {
 		},
 	} {
 		t.Run(tcase.name, func(t *testing.T) {
-			confRoot := filepath.Join(testDataDir, "conftree", tcase.name)
+			confRoot := filepath.Join(testDir, "conftree", tcase.name)
 			extraPath := FixExtraConfigPath(confRoot)
 
 			var pArgs ProgArgs

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -26,6 +27,9 @@ import (
 )
 
 func TestLoadArgs(t *testing.T) {
+	_, closer := setupTest(t)
+	t.Cleanup(closer)
+
 	type testCase struct {
 		name string
 	}
@@ -39,7 +43,8 @@ func TestLoadArgs(t *testing.T) {
 		},
 	} {
 		t.Run(tcase.name, func(t *testing.T) {
-			confRoot := filepath.Join(testDataDir, "conftree", tcase.name)
+			userDir, _ := UserRunDir()
+			confRoot := filepath.Join(userDir, "conftree", tcase.name)
 
 			environ := filepath.Join(confRoot, "_env", "vars.yaml")
 			setupEnviron(t, environ)
@@ -66,6 +71,14 @@ func TestLoadArgs(t *testing.T) {
 				t.Errorf("invalid defaults.\n>>> got:\n{%s}\n>>> expected:\n{%s}", got, expected)
 			}
 		})
+	}
+}
+
+func TestUserHomeDirWithoutEnv(t *testing.T) {
+	t.Setenv("HOME", "")
+	_, err := UserHomeDir()
+	if !errors.Is(err, SkipDirectory) {
+		t.Fatalf("returned unexpected error: %v", err)
 	}
 }
 

--- a/pkg/config/defaults_test.go
+++ b/pkg/config/defaults_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestSetDefaults(t *testing.T) {
-	closer := setupTest(t)
+	_, closer := setupTest(t)
 	t.Cleanup(closer)
 
 	pArgs := ProgArgs{}

--- a/pkg/config/environ_test.go
+++ b/pkg/config/environ_test.go
@@ -26,7 +26,7 @@ func TestFromEnv(t *testing.T) {
 	tmPol := "restricted"
 	tmScope := "pod"
 
-	closer := setupTestWithEnv(t, map[string]string{
+	_, closer := setupTestWithEnv(t, map[string]string{
 		"TOPOLOGY_MANAGER_POLICY":  tmPol,
 		"TOPOLOGY_MANAGER_SCOPE":   tmScope,
 		"NODE_NAME":                nodeName,

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -108,11 +108,20 @@ Special targets:
 	}
 
 	params := flags.Args()
+	extraConfigPath, err := validateConfigRootPath(configPath)
+	if err != nil {
+		return DefaultConfigRoot, LegacyExtraConfigPath, err
+	}
+
 	if len(params) > 1 {
-		return DefaultConfigRoot, configPath, fmt.Errorf("too many config roots given (%d), currently supported up to 1", len(params))
+		return DefaultConfigRoot, extraConfigPath, fmt.Errorf("too many config roots given (%d), currently supported up to 1", len(params))
 	}
 	if len(params) == 0 {
-		return DefaultConfigRoot, configPath, nil
+		return DefaultConfigRoot, extraConfigPath, nil
 	}
-	return params[0], FixExtraConfigPath(params[0]), nil
+	configRoot, err := validateConfigRootPath(params[0])
+	if err != nil {
+		return DefaultConfigRoot, LegacyExtraConfigPath, err
+	}
+	return configRoot, FixExtraConfigPath(configRoot), nil
 }

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -17,6 +17,12 @@ limitations under the License.
 package config
 
 import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
 	metricssrv "github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/metrics/server"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcemonitor"
 )
@@ -35,4 +41,65 @@ func Validate(pArgs *ProgArgs) error {
 	}
 
 	return nil
+}
+
+func validateConfigPath(configletPath string) (string, error) {
+	configRoot := filepath.Clean(configletPath)
+	cfgRoot, err := filepath.EvalSymlinks(configRoot)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// reset to original value, it somehow passed the symlink check
+			cfgRoot = configRoot
+		} else {
+			return "", fmt.Errorf("failed to validate configRoot path: %w", err)
+		}
+	}
+	// else either success or checking a non-existing path. Which can be still OK.
+
+	pattern, err := IsConfigRootAllowed(cfgRoot, UserRunDir, UserHomeDir)
+	if err != nil {
+		return "", err
+	}
+	if pattern == "" {
+		return "", fmt.Errorf("failed to validate configRoot path %q: does not match any allowed pattern", cfgRoot)
+	}
+	return cfgRoot, nil
+
+}
+
+func validateConfigRootPath(configRoot string) (string, error) {
+	if configRoot == "" {
+		return "", fmt.Errorf("configRoot is not allowed to be an empty string")
+	}
+	return validateConfigPath(configRoot)
+}
+
+// IsConfigRootAllowed checks if an *already cleaned and canonicalized* path is among the allowed list.
+// use `addDirFns` to inject user-dependent paths (e.g. $HOME). Returns the matched pattern, if any,
+// and error describing the failure. The error is only relevant if failed to inject user-provided paths.
+func IsConfigRootAllowed(cfgPath string, addDirFns ...func() (string, error)) (string, error) {
+	allowedPatterns := []string{
+		"/etc/rte",
+		"/run/rte",
+		"/var/rte",
+		"/usr/local/etc/rte",
+		"/etc/resource-topology-exporter", // legacy, but still supported
+	}
+	for _, addDirFn := range addDirFns {
+		userDir, err := addDirFn()
+		if errors.Is(err, SkipDirectory) {
+			continue
+		}
+		if err != nil {
+			return "", err
+		}
+		allowedPatterns = append(allowedPatterns, userDir)
+	}
+
+	for _, pattern := range allowedPatterns {
+		if strings.HasPrefix(cfgPath, pattern) {
+			return pattern, nil
+		}
+	}
+	return "", nil
 }


### PR DESCRIPTION
add validation and restrictions about configuration paths,
to reduce the chance of path traversal vulnerabilities.

Most notably:
- config root path must be one of the allowed subpaths
- configlet are expected not to escape the configuration
  directories