### PR TITLE
ghactions: fix missing upload-artifact reference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
 
     - name: archive kind logs
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: kind-logs
         path: /tmp/kind-logs


### PR DESCRIPTION
we missed to update one instance to v4