### PR TITLE
[release-0.19] resmon: podres: improve the debuggability of the PFP computation

### DIFF
--- a/pkg/podres/filter/alwayspass.go
+++ b/pkg/podres/filter/alwayspass.go
@@ -20,6 +20,20 @@ import (
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 )
 
-func AlwaysPass(_ *podresourcesapi.PodResources) bool {
-	return true
+type Result struct {
+	Allow  bool
+	Ident  string // identifier of the object which drove the decision
+	Reason string // CamelCase single identifier reason of why the decision
+}
+
+func VerifyAlwaysPass(_ *podresourcesapi.PodResources) Result {
+	return Result{
+		Allow: true,
+	}
+}
+
+// AlwaysPass is deprecated: use VerifyAlwaysPass instead
+func AlwaysPass(pr *podresourcesapi.PodResources) bool {
+	ret := VerifyAlwaysPass(pr)
+	return ret.Allow
 }

--- a/pkg/podres/filter/alwayspass.go
+++ b/pkg/podres/filter/alwayspass.go
@@ -23,7 +23,7 @@ import (
 type Result struct {
 	Allow  bool
 	Ident  string // identifier of the object which drove the decision
-	Reason string // CamelCase single identifier reason of why the decision
+	Reason string // snakeCase single identifier reason of why the decision
 }
 
 func VerifyAlwaysPass(_ *podresourcesapi.PodResources) Result {

--- a/pkg/podres/filter/alwayspass_test.go
+++ b/pkg/podres/filter/alwayspass_test.go
@@ -81,8 +81,8 @@ func TestAlwaysPass(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := AlwaysPass(tc.pr)
-			if !got {
+			got := VerifyAlwaysPass(tc.pr)
+			if !got.Allow {
 				t.Fatalf("alwayspass failed")
 			}
 		})

--- a/pkg/podres/filter/numalocality/numalocality_test.go
+++ b/pkg/podres/filter/numalocality/numalocality_test.go
@@ -6,7 +6,7 @@ import (
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 )
 
-func TestRequired(t *testing.T) {
+func TestVerify(t *testing.T) {
 	type testCase struct {
 		name     string
 		pr       *podresourcesapi.PodResources
@@ -87,8 +87,8 @@ func TestRequired(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := Required(tc.pr)
-			if tc.expected != got {
+			got := Verify(tc.pr)
+			if tc.expected != got.Allow {
 				t.Fatalf("expected=%v got=%v", tc.expected, got)
 			}
 		})


### PR DESCRIPTION
when tracking down issues like https://github.com/kubernetes/kubernetes/issues/119423 we need more precise debug information, and we can very much use a raw dump (or as raw as possible) of the list API return value before the filtering.

In this PR we augment the RTE debug capabilities and improve the debug logs.