### PR TITLE
[release-0.15] resmon: podres: improve the debuggability of the PFP computation

### DIFF
--- a/pkg/podres/filter/alwayspass.go
+++ b/pkg/podres/filter/alwayspass.go
@@ -20,6 +20,20 @@ import (
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 )
 
-func AlwaysPass(_ *podresourcesapi.PodResources) bool {
-	return true
+type Result struct {
+	Allow  bool
+	Ident  string // identifier of the object which drove the decision
+	Reason string // CamelCase single identifier reason of why the decision
+}
+
+func VerifyAlwaysPass(_ *podresourcesapi.PodResources) Result {
+	return Result{
+		Allow: true,
+	}
+}
+
+// AlwaysPass is deprecated: use VerifyAlwaysPass instead
+func AlwaysPass(pr *podresourcesapi.PodResources) bool {
+	ret := VerifyAlwaysPass(pr)
+	return ret.Allow
 }

--- a/pkg/podres/filter/alwayspass.go
+++ b/pkg/podres/filter/alwayspass.go
@@ -23,7 +23,7 @@ import (
 type Result struct {
 	Allow  bool
 	Ident  string // identifier of the object which drove the decision
-	Reason string // CamelCase single identifier reason of why the decision
+	Reason string // snakeCase single identifier reason of why the decision
 }
 
 func VerifyAlwaysPass(_ *podresourcesapi.PodResources) Result {

--- a/pkg/podres/filter/alwayspass_test.go
+++ b/pkg/podres/filter/alwayspass_test.go
@@ -81,8 +81,8 @@ func TestAlwaysPass(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := AlwaysPass(tc.pr)
-			if !got {
+			got := VerifyAlwaysPass(tc.pr)
+			if !got.Allow {
 				t.Fatalf("alwayspass failed")
 			}
 		})

--- a/pkg/podres/filter/numalocality/numalocality_test.go
+++ b/pkg/podres/filter/numalocality/numalocality_test.go
@@ -6,7 +6,7 @@ import (
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 )
 
-func TestRequired(t *testing.T) {
+func TestVerify(t *testing.T) {
 	type testCase struct {
 		name     string
 		pr       *podresourcesapi.PodResources
@@ -87,8 +87,8 @@ func TestRequired(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := Required(tc.pr)
-			if tc.expected != got {
+			got := Verify(tc.pr)
+			if tc.expected != got.Allow {
 				t.Fatalf("expected=%v got=%v", tc.expected, got)
 			}
 		})

--- a/pkg/resourcemonitor/resourcemonitor.go
+++ b/pkg/resourcemonitor/resourcemonitor.go
@@ -216,20 +216,21 @@ func (rm *resourceMonitor) Scan(excludeList ResourceExclude) (ScanResponse, erro
 		return ScanResponse{}, err
 	}
 
+	respPodRes := resp.GetPodResources()
+	klog.V(6).InfoS("podresources list", "pods", collectPodsFromPodResources(respPodRes))
+
 	st := podfingerprint.MakeStatus(rm.nodeName)
 	scanRes := ScanResponse{
 		Attributes:  topologyv1alpha2.AttributeList{},
 		Annotations: map[string]string{},
 	}
 
-	respPodRes := resp.GetPodResources()
-
 	if rm.args.PodSetFingerprint {
-		podresFilter := numalocality.Required
+		podresVerify := numalocality.Verify
 		if rm.args.PodSetFingerprintMethod == podfingerprint.MethodAll {
-			podresFilter = podresfilter.AlwaysPass
+			podresVerify = podresfilter.VerifyAlwaysPass
 		}
-		pfpSign := ComputePodFingerprint(respPodRes, &st, podresFilter)
+		pfpSign := computePodFingerprintFromPodResources(respPodRes, &st, podresVerify)
 		scanRes.Attributes = append(scanRes.Attributes, topologyv1alpha2.AttributeInfo{
 			Name:  podfingerprint.Attribute,
 			Value: pfpSign,
@@ -414,6 +415,37 @@ func (rm *resourceMonitor) updateNodeResources() error {
 	return nil
 }
 
+func computePodFingerprintFromPodResources(podRes []*podresourcesapi.PodResources, st *podfingerprint.Status, verifyFunc func(*podresourcesapi.PodResources) podresfilter.Result) string {
+	fp := podfingerprint.NewTracingFingerprint(len(podRes), st)
+	for _, pr := range podRes {
+		res := verifyFunc(pr)
+		if !res.Allow {
+			continue
+		}
+		_ = fp.AddPod(pr)
+	}
+	return fp.Sign()
+}
+
+func collectPodsFromPodResources(podRes []*podresourcesapi.PodResources) string {
+	var sb strings.Builder
+	for _, pr := range podRes {
+		desc := ""
+		nl := numalocality.Verify(pr)
+		if nl.Allow {
+			desc = "/" + nl.Ident + "=" + nl.Reason
+		}
+		// note the separator is 2 spaces
+		sb.WriteString("  " + pr.Namespace + "/" + pr.Name + desc)
+	}
+	val := sb.String()
+	if len(val) == 0 {
+		return ""
+	}
+	return val[2:]
+}
+
+// GetAllContainerDevices is deprecated and will be unexported in a future version
 func GetAllContainerDevices(podRes []*podresourcesapi.PodResources, namespace string, coreIDToNodeIDMap map[int]int) []*podresourcesapi.ContainerDevices {
 	allCntRes := []*podresourcesapi.ContainerDevices{}
 	for _, pr := range podRes {
@@ -428,6 +460,7 @@ func GetAllContainerDevices(podRes []*podresourcesapi.PodResources, namespace st
 	return allCntRes
 }
 
+// ComputePodFingerprint is deprecated and will be unexported in a future version
 func ComputePodFingerprint(podRes []*podresourcesapi.PodResources, st *podfingerprint.Status, allowFilter func(*podresourcesapi.PodResources) bool) string {
 	fp := podfingerprint.NewTracingFingerprint(len(podRes), st)
 	for _, pr := range podRes {


### PR DESCRIPTION
when tracking down issues like https://github.com/kubernetes/kubernetes/issues/119423 we need more precise debug information, and we can very much use a raw dump (or as raw as possible) of the list API return value before the filtering.

In this PR we augment the RTE debug capabilities and improve the debug logs.