### PR TITLE
[release-0.20] ghactions: ci: expand the stable branch list

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - 'main'
+      - 'release-0.21'
+      - 'release-0.20'
+      - 'release-0.16'
+      - 'release-0.15'
       - 'release-0.11'
 
 defaults:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - 'main'
+      - 'release-0.21'
+      - 'release-0.20'
+      - 'release-0.16'
+      - 'release-0.15'
       - 'release-0.11'
 
 jobs:


### PR DESCRIPTION
expand the list of branches on which we do want to run CI (stable branch).
We just don't enable CI on all the branches to save CI credits.


(cherry picked from commit 043f05f9224cf030a632e298d72954b29ef63f91)