### PR TITLE
[release-0.20] ci: ghactions bump baseimage and toolchain version

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ defaults:
 
 jobs:
   e2e-ic:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       E2E_NODE_REFERENCE: true
       E2E_TOPOLOGY_MANAGER_POLICY: single-numa-node
@@ -32,7 +32,7 @@ jobs:
       uses: actions/setup-go@v4
       id: go
       with:
-        go-version: 1.22
+        go-version: 1.23
 
     - name: show tool versions
       run: |
@@ -103,7 +103,7 @@ jobs:
       matrix:
         mode: [http, httptls]
         address: ["0.0.0.0","127.120.110.100"]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       E2E_NODE_REFERENCE: true
       E2E_TOPOLOGY_MANAGER_POLICY: single-numa-node
@@ -125,7 +125,7 @@ jobs:
       uses: actions/setup-go@v4
       id: go
       with:
-        go-version: 1.22
+        go-version: 1.23
 
     - name: show tool versions
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,14 +9,14 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
 
     - name: set up golang
       uses: actions/setup-go@v4
       with:
-        go-version: 1.22
+        go-version: 1.23
 
     - name: format
       run: ./hack/check-format.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ defaults:
 
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       RTE_CONTAINER_IMAGE: quay.io/k8stopologyawareschedwg/resource-topology-exporter
       E2E_TOPOLOGY_MANAGER_POLICY: single-numa-node
@@ -30,7 +30,7 @@ jobs:
       uses: actions/setup-go@v4
       id: go
       with:
-        go-version: 1.22
+        go-version: 1.23
 
     - name: verify modules
       run: go mod verify


### PR DESCRIPTION
bump baseimages to ubuntu-latest (no real reason to get stuck in the past) and bump toolchain to 1.23, required by tests.

note module version is still 1.22.