### PR TITLE
[release-0.19] add ncat to the resource topology exporter image

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -2,7 +2,7 @@ FROM  quay.io/centos/centos:8
 RUN cd /etc/yum.repos.d/ && \
 	sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
 	sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-RUN yum install -y hwdata && yum clean -y all
+RUN yum install -y hwdata nc && yum clean -y all
 ADD _out/resource-topology-exporter /bin/resource-topology-exporter
 RUN mkdir -p /etc/rte /etc/secrets/rte/tls /etc/secrets/rte/ca
 


### PR DESCRIPTION
This is needed for e2e coverage testing network policies.


(cherry picked from commit 03cf14f352bbed67daecadc5036dc9943b0334a7)