### PR TITLE
[release-0.19] gh actions: bump CI config

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ defaults:
 
 jobs:
   e2e-ic:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       E2E_NODE_REFERENCE: true
       E2E_TOPOLOGY_MANAGER_POLICY: single-numa-node
@@ -103,7 +103,7 @@ jobs:
       matrix:
         mode: [http, httptls]
         address: ["0.0.0.0","127.120.110.100"]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       E2E_NODE_REFERENCE: true
       E2E_TOPOLOGY_MANAGER_POLICY: single-numa-node

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
unblock CI by updating to the latest CI images
and action versions.