### PR TITLE
nrtupdater: add daemonset ownerReference

### DIFF
--- a/manifests/resource-topology-exporter-ds-notif-file.yaml
+++ b/manifests/resource-topology-exporter-ds-notif-file.yaml
@@ -34,6 +34,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: REFERENCE_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: REFERENCE_POD_NAME
           valueFrom:
             fieldRef:

--- a/manifests/resource-topology-exporter.yaml
+++ b/manifests/resource-topology-exporter.yaml
@@ -106,6 +106,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: REFERENCE_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: REFERENCE_POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -77,7 +77,7 @@ func FromFlags(pArgs *ProgArgs, args ...string) (string, string, error) {
 	CommandLine.StringVar(&pArgs.RTE.MetricsTLSCfg.KeyFile, "metrics-key-file", pArgs.RTE.MetricsTLSCfg.KeyFile, "key file name for TLS metrics serving")
 	CommandLine.BoolVar(&pArgs.RTE.MetricsTLSCfg.WantCliAuth, "metrics-want-cli-auth", pArgs.RTE.MetricsTLSCfg.WantCliAuth, "Toggle if client certificate and authentication is required")
 
-	CommandLine.StringVar(&refCnt, "reference-container", pArgs.RTE.ReferenceContainer.String(), "Reference container, used to learn about the shared cpu pool\n See: https://github.com/kubernetes/kubernetes/issues/102190\n format of spec is namespace/podname/containername.\n Alternatively, you can use the env vars REFERENCE_NAMESPACE, REFERENCE_POD_NAME, REFERENCE_CONTAINER_NAME.")
+	CommandLine.StringVar(&refCnt, "reference-container", pArgs.RTE.ReferenceContainer.String(), "Reference container, used to learn about the shared cpu pool\n See: https://github.com/kubernetes/kubernetes/issues/102190\n format of spec is namespace/podname/containername.\n Alternatively, you can use the env vars REFERENCE_NAMESPACE, REFERENCE_UID, REFERENCE_POD_NAME, REFERENCE_CONTAINER_NAME.")
 
 	CommandLine.StringVar(&pArgs.RTE.NotifyFilePath, "notify-file", pArgs.RTE.NotifyFilePath, "Notification file path.")
 	// Lets keep it simple by now and expose only "events-per-second"


### PR DESCRIPTION
We want to have an ownerReference added to NRT to point to the daemonset owner so that when the daemonset is deleted the NRT is deleted as well.

Note: if both node and daemonset owners are set, cleaning up the NRT automatically after deleting dependent objects will require deletion of **all** the owners.