### PR TITLE
[release-0.21] resmon: per-flow verbosity for NormalizeContainerDevices

### DIFF
--- a/pkg/resourcemonitor/resourcemonitor_test.go
+++ b/pkg/resourcemonitor/resourcemonitor_test.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/klog/v2"
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 	v1 "k8s.io/kubelet/pkg/apis/podresources/v1"
 
@@ -182,7 +183,8 @@ func TestNormalizeContainerDevices(t *testing.T) {
 	coreIDToNodeIDMap := getExpectedCoreToNodeMap()
 
 	Convey("When normalizing the container devices from pod resources", t, func() {
-		res := NormalizeContainerDevices(availRes.GetDevices(), availRes.GetMemory(), availRes.GetCpuIds(), coreIDToNodeIDMap)
+		VL := klog.V(999) // so high that means "never" in practice
+		res := NormalizeContainerDevices(VL, availRes.GetDevices(), availRes.GetMemory(), availRes.GetCpuIds(), coreIDToNodeIDMap)
 		expected := []*podresourcesapi.ContainerDevices{
 			{
 				ResourceName: "fake.io/net",


### PR DESCRIPTION
We call `NormalizeContainerDevices` both in the `Scan` flow and in the `updateNodeAllocatable` flow. We want different verbosity levels for them.

The `Scan` flow is done regularly, so we want to log only with VERY high verbosiness.
The `updateNodeAllocatable` flow is done seldom, possibly once, so we can afford and we actually welcome logs at low verbosity.