### PR TITLE
[release-0.18] ghactions: release: cut releases only for X.Y.0 branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.0"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
for patch releases a github tag is fine, we will
make full binary releases only on a case-by-case need.

the main driver is saving CI credits.


(cherry picked from commit 4ebe9a7ea4c8b4ade9e55f07fb1790ac24a05f1c)