### PR TITLE
[release-0.21] resmon: decouple pfpstatus dump

### DIFF
--- a/cmd/resource-topology-exporter/main.go
+++ b/cmd/resource-topology-exporter/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/k8shelpers"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/metrics"
 	metricssrv "github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/metrics/server"
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/pfpdump"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podres"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podres/middleware/podexclude"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podres/middleware/sharedcpuspool"
@@ -90,6 +91,14 @@ func main() {
 	err = metricssrv.Setup(parsedArgs.RTE.MetricsMode, metricssrv.NewConfig(parsedArgs.RTE.MetricsAddress, parsedArgs.RTE.MetricsPort, parsedArgs.RTE.MetricsTLSCfg))
 	if err != nil {
 		klog.Fatalf("failed to setup metrics server: %v", err)
+	}
+
+	if parsedArgs.Resourcemonitor.PodSetFingerprint {
+		ctx := context.TODO()
+		hnd := pfpdump.Handle{
+			Dumpfile: parsedArgs.Resourcemonitor.PodSetFingerprintStatusFile,
+		}
+		pfpdump.Execute(hnd, ctx)
 	}
 
 	hnd := resourcetopologyexporter.Handle{

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/jaypipes/ghw v0.16.0
 	github.com/jeremywohl/flatten/v2 v2.0.0-20211013061545-07e4a09fb8e4
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.1
-	github.com/k8stopologyawareschedwg/podfingerprint v0.2.2
+	github.com/k8stopologyawareschedwg/podfingerprint v0.2.3
 	github.com/mdomke/git-semver v1.0.0
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.1 h1:BI3L7hNqRvXtB42FO4NI/0ZjDDVRPOMBDFLShhFtf28=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.1/go.mod h1:AkACMQGiTgCt0lQw3m7TTU8PLH9lYKNK5e9DqFf5VuM=
-github.com/k8stopologyawareschedwg/podfingerprint v0.2.2 h1:iFHPfZInM9pz2neye5RdmORMp1hPmte1EGJYpOOzZVg=
-github.com/k8stopologyawareschedwg/podfingerprint v0.2.2/go.mod h1:C23pM15t06dXg/OihGlqBvnYzLr+MXDXJ7zMfbNAyXI=
+github.com/k8stopologyawareschedwg/podfingerprint v0.2.3 h1:nVKmzn6g7CHhDtB+jG85Db/B/ALRY9VLh5ueAfVPEHU=
+github.com/k8stopologyawareschedwg/podfingerprint v0.2.3/go.mod h1:E0bjgihZTSwRIJVjNV45Lm0C/j5w+YkGSnfpYXoI8Ws=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/pkg/pfpdump/pfpdump.go
+++ b/pkg/pfpdump/pfpdump.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pfpdump
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"k8s.io/klog/v2"
+
+	"github.com/k8stopologyawareschedwg/podfingerprint"
+)
+
+type Handle struct {
+	Dumpfile string
+}
+
+func Execute(hnd Handle, ctx context.Context) {
+	if hnd.Dumpfile == "" {
+		klog.Infof("pfpdump: no status file, nothing to do")
+		return
+	}
+
+	ch := make(chan podfingerprint.Status)
+	podfingerprint.SetCompletionSink(ch)
+	go dumpLoop(ctx, hnd, ch)
+
+	klog.Infof("pfpdump: dumping loop running with sink=%q", hnd.Dumpfile)
+}
+
+func dumpLoop(ctx context.Context, hnd Handle, updates <-chan podfingerprint.Status) {
+	klog.V(4).Infof("dump loop started")
+	defer klog.V(4).Infof("dump loop finished")
+
+	dir, file := filepath.Split(hnd.Dumpfile)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case st := <-updates:
+			err := ToFile(st, dir, file)
+			klog.V(6).Infof("pfpdump: executed fullPath=%q statusFile=%q err=%v", hnd.Dumpfile, file, err)
+			// intentionally ignore error, we must keep going.
+		}
+	}
+}
+
+func ToFile(st podfingerprint.Status, dir, file string) error {
+	data, err := json.Marshal(st)
+	if err != nil {
+		return err
+	}
+
+	dst, err := os.CreateTemp(dir, "__"+file)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(dst.Name()) // either way, we need to get rid of this
+
+	_, err = dst.Write(data)
+	if err != nil {
+		return err
+	}
+
+	err = dst.Close()
+	if err != nil {
+		return err
+	}
+
+	return os.Rename(dst.Name(), filepath.Join(dir, file))
+}

--- a/pkg/pfpdump/pfpdump_test.go
+++ b/pkg/pfpdump/pfpdump_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pfpdump
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/k8stopologyawareschedwg/podfingerprint"
+)
+
+func TestToFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	pfp := podfingerprint.Status{
+		FingerprintExpected: "pfpv0expected",
+		FingerprintComputed: "pfpv0computed",
+		Pods: []podfingerprint.NamespacedName{
+			{
+				Namespace: "foo-1",
+				Name:      "bar-1",
+			},
+			{
+				Namespace: "foo-2",
+				Name:      "bar-1",
+			},
+			{
+				Namespace: "foo-2",
+				Name:      "bar-2",
+			},
+		},
+		NodeName: "test-node.ci.dev",
+	}
+	err := ToFile(pfp, tmpDir, "pfpdump.json")
+	if err != nil {
+		t.Fatalf("ToFile(%s, %s) failed: %v", tmpDir, "pfpdump.json", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "pfpdump.json"))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	var pfp2 podfingerprint.Status
+	err = json.Unmarshal(data, &pfp2)
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	if diff := cmp.Diff(pfp, pfp2); diff != "" {
+		t.Fatalf("roundtrip error: diff=%v", diff)
+	}
+}


### PR DESCRIPTION
The initial support for pfpstatus dump was rushed in and done synchronous in the scan loop. More than a potential performance issue, this is an issue of unnecessary coupling.

This PR repays this technical debt by uncoupling the pfpstatus dump part, using the existing, built-in pofingerprint package functionality.


(cherry picked from commit 14addcee54d1bdb1d888dd87b2da34ede768012e)