### PR TITLE
config: narrow down dump-config options

### DIFF
--- a/cmd/resource-topology-exporter/main.go
+++ b/cmd/resource-topology-exporter/main.go
@@ -32,20 +32,9 @@ func main() {
 	}
 
 	if parsedArgs.DumpConfig != "" {
-		conf := parsedArgs.ToYAMLString()
-
-		if parsedArgs.DumpConfig == "-" {
-			fmt.Println(conf)
-		} else if parsedArgs.DumpConfig == ".andexit" {
-			fmt.Println(conf)
+		done := config.HandleDumpConfig(parsedArgs)
+		if done {
 			os.Exit(0)
-		} else if parsedArgs.DumpConfig == ".log" {
-			klog.Infof("current configuration:\n%s", conf)
-		} else {
-			err = os.WriteFile(parsedArgs.DumpConfig, []byte(conf), 0644)
-			if err != nil {
-				klog.Fatalf("failed to write the config to %q: %v", parsedArgs.DumpConfig, err)
-			}
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,6 +50,12 @@ func (args GlobalArgs) Clone() GlobalArgs {
 	}
 }
 
+const (
+	DumpConfigStdout string = "-"
+	DumpConfigAbort  string = ".andexit"
+	DumpConfigLog    string = ".log"
+)
+
 type ProgArgs struct {
 	Global          GlobalArgs                    `json:"global,omitempty"`
 	NRTupdater      nrtupdater.Args               `json:"nrtUpdater,omitempty"`
@@ -188,4 +194,18 @@ func UserHomeDir() (string, error) {
 		return "", SkipDirectory
 	}
 	return filepath.Join(homeDir, ".rte"), nil
+}
+
+func HandleDumpConfig(parsedArgs ProgArgs) bool {
+	conf := parsedArgs.ToYAMLString()
+	if parsedArgs.DumpConfig == DumpConfigLog {
+		klog.Infof("current configuration:\n%s", conf)
+		return false
+	}
+	if parsedArgs.DumpConfig == DumpConfigStdout {
+		fmt.Println(conf)
+		return false
+	}
+	fmt.Println(conf)
+	return true
 }

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -86,12 +86,7 @@ func FromFlags(pArgs *ProgArgs, args ...string) (string, string, error) {
 	CommandLine.Int64Var(&pArgs.RTE.MaxEventsPerTimeUnit, "max-events-per-second", pArgs.RTE.MaxEventsPerTimeUnit, "Max times per second resources will be scanned and updated")
 
 	CommandLine.BoolVar(&pArgs.Version, "version", pArgs.Version, "Output version and exit")
-	CommandLine.StringVar(&pArgs.DumpConfig, "dump-config", pArgs.DumpConfig, `dump the current configuration to the given file path. Empty string (default) disable the dumping.
-Special targets:
-. "-" for stdout.
-. ".andexit" stdout and exit right after.
-. ".log" to dump in the log".`,
-	)
+	CommandLine.Var(&DumpConfigValue{DumpConfig: &pArgs.DumpConfig}, "dump-config", `dump the current configuration to either stdout (use "-") or the log (use ".log").`)
 
 	err := CommandLine.Parse(args)
 	if err != nil {
@@ -124,4 +119,23 @@ Special targets:
 	}
 	configRoot := params[0]
 	return configRoot, FixExtraConfigPath(configRoot), nil
+}
+
+type DumpConfigValue struct {
+	DumpConfig *string
+}
+
+func (v DumpConfigValue) String() string {
+	if v.DumpConfig == nil {
+		return ""
+	}
+	return *v.DumpConfig
+}
+
+func (v DumpConfigValue) Set(s string) error {
+	if s != DumpConfigStdout && s != DumpConfigAbort && s != DumpConfigLog {
+		return fmt.Errorf("invalid dump config target: %q", s)
+	}
+	*v.DumpConfig = s
+	return nil
 }


### PR DESCRIPTION
remove rarely used and potentially (very much in theory) dump config options, considering dump config is in turn rarely used.

- drop `.andexit`. Use this pattern instead:
```
rte --dump-config=- --version
```
- drop custom file target. Use stdout redirect instead.