### PR TITLE
metrics: tls: add TLS min version and cipher suite flags for httptls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.34.2
 	k8s.io/apimachinery v0.34.2
 	k8s.io/client-go v0.34.2
+	k8s.io/component-base v0.34.2
 	k8s.io/cri-client v0.34.2
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kubelet v0.34.2
@@ -94,7 +95,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/component-base v0.34.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/pkg/config/cfgdispatch.go
+++ b/pkg/config/cfgdispatch.go
@@ -129,6 +129,8 @@ func dispatchConfObj(obj map[string]interface{}, pArgs *ProgArgs) error {
 		{key: "topologyExporter.metricsTLS.certFile", out: &pArgs.RTE.MetricsTLSCfg.CertFile},
 		{key: "topologyExporter.metricsTLS.keyFile", out: &pArgs.RTE.MetricsTLSCfg.KeyFile},
 		{key: "topologyExporter.metricsTLS.wantCliAuth", out: &pArgs.RTE.MetricsTLSCfg.WantCliAuth},
+		{key: "topologyExporter.metricsTLS.minTLSVersion", out: &pArgs.RTE.MetricsTLSCfg.MinTLSVersion},
+		{key: "topologyExporter.metricsTLS.cipherSuites", out: &pArgs.RTE.MetricsTLSCfg.CipherSuites},
 	}
 
 	for _, cb := range cbs {

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -76,6 +76,8 @@ func FromFlags(pArgs *ProgArgs, args ...string) (string, string, error) {
 	CommandLine.StringVar(&pArgs.RTE.MetricsTLSCfg.CertFile, "metrics-cert-file", pArgs.RTE.MetricsTLSCfg.CertFile, "certificate file name for TLS metrics serving")
 	CommandLine.StringVar(&pArgs.RTE.MetricsTLSCfg.KeyFile, "metrics-key-file", pArgs.RTE.MetricsTLSCfg.KeyFile, "key file name for TLS metrics serving")
 	CommandLine.BoolVar(&pArgs.RTE.MetricsTLSCfg.WantCliAuth, "metrics-want-cli-auth", pArgs.RTE.MetricsTLSCfg.WantCliAuth, "Toggle if client certificate and authentication is required")
+	CommandLine.StringVar(&pArgs.RTE.MetricsTLSCfg.MinTLSVersion, "metrics-tls-min-version", pArgs.RTE.MetricsTLSCfg.MinTLSVersion, "Minimum TLS version for HTTPS metrics (e.g. VersionTLS12, VersionTLS13). Empty uses Go defaults for TLS handshake. Use the same names as kube-apiserver --tls-min-version.")
+	CommandLine.StringVar(&pArgs.RTE.MetricsTLSCfg.CipherSuites, "metrics-tls-cipher-suites", pArgs.RTE.MetricsTLSCfg.CipherSuites, "Comma-separated TLS 1.2 cipher suite names for HTTPS metrics (crypto/tls names as for kube-apiserver --tls-cipher-suites). Ignored when min version is TLS 1.3. Empty uses Go defaults.")
 
 	CommandLine.StringVar(&refCnt, "reference-container", pArgs.RTE.ReferenceContainer.String(), "Reference container, used to learn about the shared cpu pool\n See: https://github.com/kubernetes/kubernetes/issues/102190\n format of spec is namespace/podname/containername.\n Alternatively, you can use the env vars REFERENCE_NAMESPACE, REFERENCE_POD_NAME, REFERENCE_CONTAINER_NAME.")
 

--- a/pkg/metrics/server/setup.go
+++ b/pkg/metrics/server/setup.go
@@ -54,10 +54,14 @@ func NewDefaultTLSConfig() TLSConfig {
 }
 
 type TLSConfig struct {
-	CertsDir    string `json:"certsDir,omitempty"`
-	CertFile    string `json:"certFile,omitempty"`
-	KeyFile     string `json:"keyFile,omitempty"`
-	WantCliAuth bool   `json:"wantCliAuth,omitempty"`
+	CertsDir      string `json:"certsDir,omitempty"`
+	CertFile      string `json:"certFile,omitempty"`
+	KeyFile       string `json:"keyFile,omitempty"`
+	WantCliAuth   bool   `json:"wantCliAuth,omitempty"`
+	MinTLSVersion string `json:"minTLSVersion,omitempty"`
+	// CipherSuites is a comma-separated list of TLS 1.2 cipher names as accepted by
+	// k8s.io/component-base/cli/flag.TLSCipherSuites (same as kube-apiserver --tls-cipher-suites).
+	CipherSuites string `json:"cipherSuites,omitempty"`
 }
 
 type Config struct {
@@ -80,9 +84,12 @@ func NewDefaultConfig() Config {
 
 func (conf TLSConfig) Clone() TLSConfig {
 	return TLSConfig{
-		CertsDir: conf.CertsDir,
-		CertFile: conf.CertFile,
-		KeyFile:  conf.KeyFile,
+		CertsDir:      conf.CertsDir,
+		CertFile:      conf.CertFile,
+		KeyFile:       conf.KeyFile,
+		WantCliAuth:   conf.WantCliAuth,
+		MinTLSVersion: conf.MinTLSVersion,
+		CipherSuites:  conf.CipherSuites,
 	}
 }
 
@@ -161,15 +168,22 @@ func Setup(mode string, conf Config) error {
 		return fmt.Errorf("unknown mode: %v", mode)
 	}
 
+	var tlsOpts []func(*tls.Config)
+	if secureServing {
+		var err error
+		tlsOpts, err = buildSecureMetricsTLSOpts(conf.TLS)
+		if err != nil {
+			return err
+		}
+	}
+
 	opts := ctrlmetricssrv.Options{
 		SecureServing: secureServing,
 		BindAddress:   conf.BindAddress(),
 		CertDir:       conf.TLS.CertsDir,
 		CertName:      conf.TLS.CertFile,
 		KeyName:       conf.TLS.KeyFile,
-		TLSOpts: []func(*tls.Config){
-			WithClientAuth(conf.TLS.WantCliAuth),
-		},
+		TLSOpts:       tlsOpts,
 	}
 	srv, err := ctrlmetricssrv.NewServer(opts, nil, nil)
 	if err != nil {

--- a/pkg/metrics/server/tls_policy.go
+++ b/pkg/metrics/server/tls_policy.go
@@ -1,0 +1,106 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"crypto/tls"
+	"fmt"
+	"strings"
+
+	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog/v2"
+)
+
+// metricsTLSPolicyOpts returns TLS option funcs that apply MinVersion, MaxVersion, and
+// CipherSuites when minTLSVersion and/or cipherSuites are set. It does not set application-layer
+// protocol (ALPN); callers composing a full metrics listener should add that separately.
+// Empty minTLSVersion and cipherSuites means no policy is applied (callers should not append these opts).
+// Version names follow Kubernetes apiserver/scheduler flags (e.g. VersionTLS12, VersionTLS13).
+// Cipher names follow crypto/tls cipher suite names as accepted by k8s.io/component-base/cli/flag.TLSCipherSuites
+// (comma-separated).
+func metricsTLSPolicyOpts(minTLSVersion, cipherSuitesCSV string) ([]func(*tls.Config), error) {
+	minName := strings.TrimSpace(minTLSVersion)
+	cipherNames := splitNonEmptyCSV(cipherSuitesCSV)
+	if minName == "" && len(cipherNames) == 0 {
+		return nil, nil
+	}
+
+	minVer, err := cliflag.TLSVersion(minName)
+	if err != nil {
+		return nil, err
+	}
+	cipherIDs, err := cliflag.TLSCipherSuites(cipherNames)
+	if err != nil {
+		return nil, err
+	}
+
+	if minVer == tls.VersionTLS13 {
+		return []func(*tls.Config){tls13PolicyOpt(cipherNames)}, nil
+	}
+	return []func(*tls.Config){tls12AndEarlierPolicyOpt(minVer, cipherIDs)}, nil
+}
+
+func tls13PolicyOpt(ignoredCipherNames []string) func(*tls.Config) {
+	if len(ignoredCipherNames) > 0 {
+		klog.V(2).InfoS("TLS 1.3 uses fixed cipher suites; ignoring configured TLS cipher list",
+			"cipherSuiteCount", len(ignoredCipherNames))
+	}
+	return func(cfg *tls.Config) {
+		cfg.MinVersion = tls.VersionTLS13
+		cfg.MaxVersion = tls.VersionTLS13
+		cfg.CipherSuites = nil
+	}
+}
+
+func tls12AndEarlierPolicyOpt(minVer uint16, cipherIDs []uint16) func(*tls.Config) {
+	return func(cfg *tls.Config) {
+		cfg.MinVersion = minVer
+		cfg.CipherSuites = cipherIDs
+	}
+}
+
+func splitNonEmptyCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// withHTTP11 sets ALPN for the metrics HTTP/1.1 listener.
+func withHTTP11() func(*tls.Config) {
+	return func(cfg *tls.Config) {
+		cfg.NextProtos = []string{"http/1.1"}
+	}
+}
+
+// buildSecureMetricsTLSOpts composes TLSOpts for HTTPS metrics: HTTP/1.1 ALPN, optional
+// TLS version/cipher policy, and client certificate settings.
+func buildSecureMetricsTLSOpts(tlsConf TLSConfig) ([]func(*tls.Config), error) {
+	policyOpts, err := metricsTLSPolicyOpts(tlsConf.MinTLSVersion, tlsConf.CipherSuites)
+	if err != nil {
+		return nil, fmt.Errorf("metrics TLS policy: %w", err)
+	}
+	out := []func(*tls.Config){withHTTP11()}
+	out = append(out, policyOpts...)
+	out = append(out, WithClientAuth(tlsConf.WantCliAuth))
+	return out, nil
+}

--- a/pkg/metrics/server/tls_policy_test.go
+++ b/pkg/metrics/server/tls_policy_test.go
@@ -1,0 +1,294 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"crypto/tls"
+	"reflect"
+	"testing"
+)
+
+func TestMetricsTLSPolicyOpts(t *testing.T) {
+	type testCase struct {
+		name          string
+		minTLSVersion string
+		cipherSuites  string
+		expectErr     bool
+		wantOptCount  int
+		check         func(t *testing.T, cfg *tls.Config)
+	}
+
+	testCases := []testCase{
+		{
+			name:         "empty min and empty ciphers returns no opts",
+			wantOptCount: 0,
+		},
+		{
+			name:          "TLS 1.2 with two ciphers",
+			minTLSVersion: "VersionTLS12",
+			cipherSuites:  "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			wantOptCount:  1,
+			check: func(t *testing.T, cfg *tls.Config) {
+				t.Helper()
+				checkMinTLSVersion(t, cfg, tls.VersionTLS12)
+				if cfg.MaxVersion != 0 {
+					t.Errorf("MaxVersion should be unset, got %x", cfg.MaxVersion)
+				}
+				if len(cfg.CipherSuites) != 2 {
+					t.Errorf("CipherSuites: want 2 entries, got %d", len(cfg.CipherSuites))
+				}
+			},
+		},
+		{
+			name:          "TLS 1.2 min only uses Go default ciphers",
+			minTLSVersion: "VersionTLS12",
+			wantOptCount:  1,
+			check: func(t *testing.T, cfg *tls.Config) {
+				t.Helper()
+				checkMinTLSVersion(t, cfg, tls.VersionTLS12)
+				if len(cfg.CipherSuites) != 0 {
+					t.Errorf("CipherSuites: want empty when unset, got %#v", cfg.CipherSuites)
+				}
+			},
+		},
+		{
+			name:         "ciphers only defaults min to TLS 1.2",
+			cipherSuites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			wantOptCount: 1,
+			check: func(t *testing.T, cfg *tls.Config) {
+				t.Helper()
+				checkMinTLSVersion(t, cfg, tls.VersionTLS12)
+				if len(cfg.CipherSuites) != 1 {
+					t.Errorf("CipherSuites: got %#v", cfg.CipherSuites)
+				}
+			},
+		},
+		{
+			name:          "TLS 1.3 pins min/max and clears explicit cipher list",
+			minTLSVersion: "VersionTLS13",
+			cipherSuites:  "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+			wantOptCount:  1,
+			check: func(t *testing.T, cfg *tls.Config) {
+				t.Helper()
+				checkTLS13OnlyNoExplicitCiphers(t, cfg)
+			},
+		},
+		{
+			name:          "TLS 1.3 without cipher list",
+			minTLSVersion: "VersionTLS13",
+			wantOptCount:  1,
+			check: func(t *testing.T, cfg *tls.Config) {
+				t.Helper()
+				checkTLS13OnlyNoExplicitCiphers(t, cfg)
+			},
+		},
+		{
+			name:          "TLS 1.11 min with cipher",
+			minTLSVersion: "VersionTLS11",
+			cipherSuites:  "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+			wantOptCount:  1,
+			check: func(t *testing.T, cfg *tls.Config) {
+				t.Helper()
+				checkMinTLSVersion(t, cfg, tls.VersionTLS11)
+				if len(cfg.CipherSuites) != 1 {
+					t.Errorf("CipherSuites: want 1 entry, got %d", len(cfg.CipherSuites))
+				}
+			},
+		},
+		{
+			name:          "unknown min version",
+			minTLSVersion: "VersionTLS99",
+			expectErr:     true,
+		},
+		{
+			name:          "unknown cipher",
+			minTLSVersion: "VersionTLS12",
+			cipherSuites:  "NOT_A_REAL_CIPHER",
+			expectErr:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, err := metricsTLSPolicyOpts(tc.minTLSVersion, tc.cipherSuites)
+			if !checkTLSPolicyOutcome(t, err, tc.expectErr, opts, tc.wantOptCount) {
+				return
+			}
+			if tc.check != nil && len(opts) > 0 {
+				cfg := &tls.Config{}
+				applyTLSOptionFuncs(cfg, opts[:1])
+				tc.check(t, cfg)
+			}
+		})
+	}
+}
+
+func TestSplitNonEmptyCSV(t *testing.T) {
+	type testCase struct {
+		name     string
+		input    string
+		expected []string
+	}
+
+	testCases := []testCase{
+		{
+			name:     "trims and drops empties",
+			input:    " a , , b,c ",
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "single token",
+			input:    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			expected: []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []string{},
+		},
+		{
+			name:     "only commas and spaces",
+			input:    " , ,  ",
+			expected: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := splitNonEmptyCSV(tc.input)
+			if !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("splitNonEmptyCSV(%q): got %#v, want %#v", tc.input, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestBuildSecureMetricsTLSOpts(t *testing.T) {
+	type testCase struct {
+		name         string
+		tlsConf      TLSConfig
+		expectErr    bool
+		wantOptCount int
+		check        func(t *testing.T, cfg *tls.Config)
+	}
+
+	testCases := []testCase{
+		{
+			name:         "no policy adds ALPN then no client auth",
+			tlsConf:      TLSConfig{},
+			wantOptCount: 2,
+			check: func(t *testing.T, cfg *tls.Config) {
+				t.Helper()
+				checkNextProtosHTTP11(t, cfg)
+				checkClientAuth(t, cfg, tls.NoClientCert)
+			},
+		},
+		{
+			name: "policy and client certificate required",
+			tlsConf: TLSConfig{
+				MinTLSVersion: "VersionTLS12",
+				CipherSuites:  "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				WantCliAuth:   true,
+			},
+			wantOptCount: 3,
+			check: func(t *testing.T, cfg *tls.Config) {
+				t.Helper()
+				checkNextProtosHTTP11(t, cfg)
+				checkMinTLSVersion(t, cfg, tls.VersionTLS12)
+				checkClientAuth(t, cfg, tls.RequireAndVerifyClientCert)
+			},
+		},
+		{
+			name: "invalid policy surfaces error",
+			tlsConf: TLSConfig{
+				MinTLSVersion: "VersionTLS12",
+				CipherSuites:  "BAD_CIPHER",
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, err := buildSecureMetricsTLSOpts(tc.tlsConf)
+			if !checkTLSPolicyOutcome(t, err, tc.expectErr, opts, tc.wantOptCount) {
+				return
+			}
+			if tc.check != nil {
+				cfg := &tls.Config{}
+				applyTLSOptionFuncs(cfg, opts)
+				tc.check(t, cfg)
+			}
+		})
+	}
+}
+
+// checkTLSPolicyOutcome checks error expectations and option count. It returns false if the
+// subtest should not continue (expected error path or fatal test failure).
+func checkTLSPolicyOutcome(t *testing.T, err error, expectErr bool, opts []func(*tls.Config), wantOptCount int) bool {
+	t.Helper()
+	if expectErr {
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		return false
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(opts) != wantOptCount {
+		t.Fatalf("want %d TLS opt funcs, got %d", wantOptCount, len(opts))
+	}
+	return true
+}
+
+func applyTLSOptionFuncs(cfg *tls.Config, opts []func(*tls.Config)) {
+	for _, fn := range opts {
+		fn(cfg)
+	}
+}
+
+func checkMinTLSVersion(t *testing.T, cfg *tls.Config, want uint16) {
+	t.Helper()
+	if cfg.MinVersion != want {
+		t.Errorf("MinVersion: got %x want %x", cfg.MinVersion, want)
+	}
+}
+
+func checkNextProtosHTTP11(t *testing.T, cfg *tls.Config) {
+	t.Helper()
+	if len(cfg.NextProtos) != 1 || cfg.NextProtos[0] != "http/1.1" {
+		t.Errorf("NextProtos: want [http/1.1], got %#v", cfg.NextProtos)
+	}
+}
+
+func checkTLS13OnlyNoExplicitCiphers(t *testing.T, cfg *tls.Config) {
+	t.Helper()
+	if cfg.MinVersion != tls.VersionTLS13 || cfg.MaxVersion != tls.VersionTLS13 {
+		t.Errorf("want TLS 1.3 only, got min=%x max=%x", cfg.MinVersion, cfg.MaxVersion)
+	}
+	if cfg.CipherSuites != nil {
+		t.Errorf("TLS 1.3 should leave CipherSuites nil, got %#v", cfg.CipherSuites)
+	}
+}
+
+func checkClientAuth(t *testing.T, cfg *tls.Config, want tls.ClientAuthType) {
+	t.Helper()
+	if cfg.ClientAuth != want {
+		t.Errorf("ClientAuth: got %v want %v", cfg.ClientAuth, want)
+	}
+}


### PR DESCRIPTION
Expose cluster-aligned TLS policy for the HTTPS metrics listener. New flags` --metrics-tls-min-version `and
`--metrics-tls-cipher-suites` (and topologyExporter.metricsTLS.* in config) use k8s.io/component-base/cli/flag parsing.