### PR TITLE
attr: encode containers' numa placements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/jaypipes/ghw v0.21.3-0.20260109185716-ee0aed93f45d
 	github.com/jeremywohl/flatten/v2 v2.0.0-20211013061545-07e4a09fb8e4
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.1
+	github.com/k8stopologyawareschedwg/numaplacement v0.0.0-20260415075341-05c4e9728963
 	github.com/k8stopologyawareschedwg/podfingerprint v0.2.3
 	github.com/mdomke/git-semver v1.0.0
 	github.com/onsi/ginkgo/v2 v2.27.2

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,8 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.1 h1:BI3L7hNqRvXtB42FO4NI/0ZjDDVRPOMBDFLShhFtf28=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.1/go.mod h1:AkACMQGiTgCt0lQw3m7TTU8PLH9lYKNK5e9DqFf5VuM=
+github.com/k8stopologyawareschedwg/numaplacement v0.0.0-20260415075341-05c4e9728963 h1:hyJsE9sonWaqqttrJCIj7HC3Xr/XxAfsz8mTI4Yvbng=
+github.com/k8stopologyawareschedwg/numaplacement v0.0.0-20260415075341-05c4e9728963/go.mod h1:wU3DV2l+5mzMLufnTYhtsiyXqiNwfDMN0Hq29c+qXU4=
 github.com/k8stopologyawareschedwg/podfingerprint v0.2.3 h1:nVKmzn6g7CHhDtB+jG85Db/B/ALRY9VLh5ueAfVPEHU=
 github.com/k8stopologyawareschedwg/podfingerprint v0.2.3/go.mod h1:E0bjgihZTSwRIJVjNV45Lm0C/j5w+YkGSnfpYXoI8Ws=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -174,6 +174,8 @@ func Finalize(pArgs *ProgArgs) error {
 		}
 	}
 
+	pArgs.Resourcemonitor.TopologyManagerPolicy = pArgs.RTE.TopologyManagerPolicy
+
 	return err
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -24,6 +24,10 @@ import (
 	"testing"
 
 	"sigs.k8s.io/yaml"
+
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/nrtupdater"
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcemonitor"
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/resourcetopologyexporter"
 )
 
 func TestLoadArgs(t *testing.T) {
@@ -79,6 +83,28 @@ func TestUserHomeDirWithoutEnv(t *testing.T) {
 	_, err := UserHomeDir()
 	if !errors.Is(err, SkipDirectory) {
 		t.Fatalf("returned unexpected error: %v", err)
+	}
+}
+
+func TestFinalizeSyncsTopologyManagerPolicy(t *testing.T) {
+	pArgs := ProgArgs{
+		NRTupdater: nrtupdater.Args{
+			Hostname: "test-node",
+		},
+		RTE: resourcetopologyexporter.Args{
+			TopologyManagerPolicy: "single-numa-node",
+		},
+		Resourcemonitor: resourcemonitor.Args{
+			TopologyManagerPolicy: "restricted",
+		},
+	}
+
+	err := Finalize(&pArgs)
+	if err != nil {
+		t.Fatalf("Finalize returned unexpected error: %v", err)
+	}
+	if pArgs.Resourcemonitor.TopologyManagerPolicy != pArgs.RTE.TopologyManagerPolicy {
+		t.Fatalf("TopologyManagerPolicy mismatch: got %q want %q", pArgs.Resourcemonitor.TopologyManagerPolicy, pArgs.RTE.TopologyManagerPolicy)
 	}
 }
 

--- a/pkg/podres/filter/numalocality/numalocality.go
+++ b/pkg/podres/filter/numalocality/numalocality.go
@@ -17,6 +17,8 @@ limitations under the License.
 package numalocality
 
 import (
+	"fmt"
+
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 
 	podresfilter "github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podres/filter"
@@ -109,4 +111,45 @@ func VerifyContainer(cnt *podresourcesapi.ContainerResources) podresfilter.Resul
 	return podresfilter.Result{
 		Allow: false,
 	}
+}
+
+// ResolveContainerPlacement finds the single NUMA node placement for a container;
+// it returns the NUMA node ID if found, otherwise it returns -1.
+// IMPORTANT: multiple-NUMA affinity is not supported (yet), thus this should be called only
+// on single NUMA node topology manager policy.
+func ResolveContainerPlacement(coreIDToNodeIDMap map[int]int, cnt *podresourcesapi.ContainerResources) (bool, int, error) {
+	eligibleForPlacement := true
+	if cnt == nil {
+		return !eligibleForPlacement, -1, fmt.Errorf("nil container resources")
+	}
+
+	if len(cnt.CpuIds) > 0 {
+		nodeID, ok := coreIDToNodeIDMap[int(cnt.CpuIds[0])]
+		if !ok {
+			//should never happen
+			return eligibleForPlacement, -1, fmt.Errorf("CPU ID %d not found in coreIDToNodeIDMap", cnt.CpuIds[0])
+		}
+		return eligibleForPlacement, nodeID, nil
+	}
+
+	// TODO: handle multi-NUMAs for devices
+	// we need to know if on multi-NUMA topology this data is available by
+	// the pod-resources API or if it needs other means to get the NUMA node ID
+	// https://redhat.atlassian.net/browse/CNF-23537
+	// currently this assumes single NUMA node for all devices containers
+	for _, dev := range cnt.Devices {
+		nodeID := GetNUMAID(dev.Topology)
+		if len(dev.DeviceIds) > 0 && nodeID != -1 {
+			return eligibleForPlacement, nodeID, nil
+		}
+	}
+
+	for _, mem := range cnt.Memory {
+		nodeID := GetNUMAID(mem.Topology)
+		if nodeID != -1 {
+			return eligibleForPlacement, nodeID, nil
+		}
+	}
+
+	return !eligibleForPlacement, -1, nil
 }

--- a/pkg/podres/filter/numalocality/numalocality.go
+++ b/pkg/podres/filter/numalocality/numalocality.go
@@ -56,18 +56,18 @@ func Required(pr *podresourcesapi.PodResources) bool {
 	return got.Allow
 }
 
-func IsPresent(topo *podresourcesapi.TopologyInfo) bool {
+func GetNUMAID(topo *podresourcesapi.TopologyInfo) int {
 	if topo == nil || topo.Nodes == nil {
-		return false
+		return -1
 	}
 	// if Nodes is not given, this means "don't care about locality". It's a legal representation.
 	for _, node := range topo.Nodes {
 		// setting node.ID == -1 is also a legal representation for "don't care about locality".
 		if node.ID >= 0 {
-			return true
+			return int(node.ID)
 		}
 	}
-	return false
+	return -1
 }
 
 func VerifyContainer(cnt *podresourcesapi.ContainerResources) podresfilter.Result {
@@ -88,7 +88,7 @@ func VerifyContainer(cnt *podresourcesapi.ContainerResources) podresfilter.Resul
 		}
 	}
 	for _, mem := range cnt.Memory {
-		if IsPresent(mem.Topology) {
+		if GetNUMAID(mem.Topology) != -1 {
 			return podresfilter.Result{
 				Allow:  true,
 				Ident:  cnt.Name,
@@ -97,7 +97,7 @@ func VerifyContainer(cnt *podresourcesapi.ContainerResources) podresfilter.Resul
 		}
 	}
 	for _, dev := range cnt.Devices {
-		if len(dev.DeviceIds) > 0 && IsPresent(dev.Topology) {
+		if len(dev.DeviceIds) > 0 && GetNUMAID(dev.Topology) != -1 {
 			return podresfilter.Result{
 				Allow:  true,
 				Ident:  cnt.Name,

--- a/pkg/podres/filter/numalocality/numalocality.go
+++ b/pkg/podres/filter/numalocality/numalocality.go
@@ -35,33 +35,9 @@ func Verify(pr *podresourcesapi.PodResources) podresfilter.Result {
 		}
 	}
 	for _, cr := range pr.Containers {
-		// there's no correct order for checks here, or faster.
-		// CPUs are the most frequent (because there's always here) exclusively
-		// assigned devices, so we start from here.
-		if len(cr.CpuIds) > 0 {
-			return podresfilter.Result{
-				Allow:  true,
-				Ident:  cr.Name,
-				Reason: CPU,
-			}
-		}
-		for _, mem := range cr.Memory {
-			if IsPresent(mem.Topology) {
-				return podresfilter.Result{
-					Allow:  true,
-					Ident:  cr.Name,
-					Reason: Memory,
-				}
-			}
-		}
-		for _, dev := range cr.Devices {
-			if len(dev.DeviceIds) > 0 && IsPresent(dev.Topology) {
-				return podresfilter.Result{
-					Allow:  true,
-					Ident:  cr.Name,
-					Reason: Device,
-				}
-			}
+		res := VerifyContainer(cr)
+		if res.Allow {
+			return res
 		}
 	}
 	return podresfilter.Result{
@@ -92,4 +68,45 @@ func IsPresent(topo *podresourcesapi.TopologyInfo) bool {
 		}
 	}
 	return false
+}
+
+func VerifyContainer(cnt *podresourcesapi.ContainerResources) podresfilter.Result {
+	if cnt == nil {
+		return podresfilter.Result{
+			Allow: false,
+		}
+	}
+
+	// there's no correct order for checks here, or faster.
+	// CPUs are the most frequent (because there's always here) exclusively
+	// assigned devices, so we start from here.
+	if len(cnt.CpuIds) > 0 {
+		return podresfilter.Result{
+			Allow:  true,
+			Ident:  cnt.Name,
+			Reason: CPU,
+		}
+	}
+	for _, mem := range cnt.Memory {
+		if IsPresent(mem.Topology) {
+			return podresfilter.Result{
+				Allow:  true,
+				Ident:  cnt.Name,
+				Reason: Memory,
+			}
+		}
+	}
+	for _, dev := range cnt.Devices {
+		if len(dev.DeviceIds) > 0 && IsPresent(dev.Topology) {
+			return podresfilter.Result{
+				Allow:  true,
+				Ident:  cnt.Name,
+				Reason: Device,
+			}
+		}
+	}
+
+	return podresfilter.Result{
+		Allow: false,
+	}
 }

--- a/pkg/podres/filter/numalocality/numalocality_test.go
+++ b/pkg/podres/filter/numalocality/numalocality_test.go
@@ -154,5 +154,138 @@ func TestGetNUMAID(t *testing.T) {
 	}
 }
 
-// {"pod_resources":[{"name":"image-registry-78b84dc9f9-zwxtk","namespace":"image-registry","containers":[{"name":"registry"}]}]}
-// {"pod_resources":[{"name":"image-registry-78b84dc9f9-zwxtk","namespace":"image-registry","containers":[{"name":"registry"}]}, {"name":"network-check-source-677bdb7d9-lqrcb","namespace":"network-diagnostics","containers":[{"name":"check-endpoints"}]},{"name":"network-check-target-m9mlq","namespace":"network-diagnostics","containers":[{"name":"network-check-target-container"}]}]}
+func TestResolveContainerPlacement(t *testing.T) {
+	coreIDToNodeIDMap := map[int]int{
+		0: 0,
+		1: 1,
+	}
+
+	type testCase struct {
+		name             string
+		cnt              *podresourcesapi.ContainerResources
+		expectedEligible bool
+		expectedNodeID   int
+		expectError      bool
+	}
+
+	testCases := []testCase{
+		{
+			name:             "nil container",
+			cnt:              nil,
+			expectedEligible: false,
+			expectedNodeID:   -1,
+			expectError:      true,
+		},
+		{
+			name: "cpu placement found",
+			cnt: &podresourcesapi.ContainerResources{
+				Name:   "cpu-found",
+				CpuIds: []int64{1},
+			},
+			expectedEligible: true,
+			expectedNodeID:   1,
+			expectError:      false,
+		},
+		{
+			name: "cpu placement missing from map",
+			cnt: &podresourcesapi.ContainerResources{
+				Name:   "cpu-missing",
+				CpuIds: []int64{9},
+			},
+			// Missing CPU in core map is treated as an error while still eligible for placement semantics.
+			expectedEligible: true,
+			expectedNodeID:   -1,
+			expectError:      true,
+		},
+		{
+			name: "device placement found",
+			cnt: &podresourcesapi.ContainerResources{
+				Name: "dev-found",
+				Devices: []*podresourcesapi.ContainerDevices{
+					{
+						ResourceName: "example.com/gpu",
+						DeviceIds:    []string{"gpu-0"},
+						Topology: &podresourcesapi.TopologyInfo{
+							Nodes: []*podresourcesapi.NUMANode{{ID: 0}},
+						},
+					},
+				},
+			},
+			expectedEligible: true,
+			expectedNodeID:   0,
+			expectError:      false,
+		},
+		{
+			name: "memory placement found after non-matching device",
+			cnt: &podresourcesapi.ContainerResources{
+				Name: "mem-found",
+				Devices: []*podresourcesapi.ContainerDevices{
+					{
+						ResourceName: "example.com/fpga",
+						DeviceIds:    []string{"fpga-0"},
+						Topology: &podresourcesapi.TopologyInfo{
+							Nodes: []*podresourcesapi.NUMANode{{ID: -1}},
+						},
+					},
+				},
+				Memory: []*podresourcesapi.ContainerMemory{
+					{
+						MemoryType: "memory",
+						Size:       1024,
+						Topology: &podresourcesapi.TopologyInfo{
+							Nodes: []*podresourcesapi.NUMANode{{ID: 1}},
+						},
+					},
+				},
+			},
+			expectedEligible: true,
+			expectedNodeID:   1,
+			expectError:      false,
+		},
+		{
+			name: "no placement detected",
+			cnt: &podresourcesapi.ContainerResources{
+				Name: "no-placement",
+				Devices: []*podresourcesapi.ContainerDevices{
+					{
+						ResourceName: "example.com/nic",
+						DeviceIds:    []string{},
+						Topology: &podresourcesapi.TopologyInfo{
+							Nodes: []*podresourcesapi.NUMANode{{ID: 0}},
+						},
+					},
+				},
+				Memory: []*podresourcesapi.ContainerMemory{
+					{
+						MemoryType: "memory",
+						Size:       1024,
+						Topology: &podresourcesapi.TopologyInfo{
+							Nodes: []*podresourcesapi.NUMANode{{ID: -1}},
+						},
+					},
+				},
+			},
+			expectedEligible: false,
+			expectedNodeID:   -1,
+			expectError:      false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			eligible, nodeID, err := ResolveContainerPlacement(coreIDToNodeIDMap, tc.cnt)
+			if tc.expectError && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.expectError && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if eligible != tc.expectedEligible {
+				t.Fatalf("expected eligible=%v got=%v", tc.expectedEligible, eligible)
+			}
+			if nodeID != tc.expectedNodeID {
+				t.Fatalf("expected nodeID=%d got=%d", tc.expectedNodeID, nodeID)
+			}
+		})
+	}
+}

--- a/pkg/podres/filter/numalocality/numalocality_test.go
+++ b/pkg/podres/filter/numalocality/numalocality_test.go
@@ -95,30 +95,30 @@ func TestVerify(t *testing.T) {
 	}
 }
 
-func TestIsPresent(t *testing.T) {
+func TestGetNUMAID(t *testing.T) {
 	type testCase struct {
 		name     string
 		topo     *podresourcesapi.TopologyInfo
-		expected bool
+		expected int
 	}
 
 	testCases := []testCase{
 		{
 			name:     "nil",
 			topo:     nil,
-			expected: false,
+			expected: -1,
 		},
 		{
 			name:     "nil nodes",
 			topo:     &podresourcesapi.TopologyInfo{},
-			expected: false,
+			expected: -1,
 		},
 		{
 			name: "empty nodes",
 			topo: &podresourcesapi.TopologyInfo{
 				Nodes: []*podresourcesapi.NUMANode{},
 			},
-			expected: false,
+			expected: -1,
 		},
 		{
 			name: "any NUMA locality",
@@ -129,7 +129,7 @@ func TestIsPresent(t *testing.T) {
 					},
 				},
 			},
-			expected: false,
+			expected: -1,
 		},
 		{
 			name: "defined NUMA locality",
@@ -140,13 +140,13 @@ func TestIsPresent(t *testing.T) {
 					},
 				},
 			},
-			expected: true,
+			expected: 1,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := IsPresent(tc.topo)
+			got := GetNUMAID(tc.topo)
 			if tc.expected != got {
 				t.Fatalf("expected=%v got=%v", tc.expected, got)
 			}

--- a/pkg/resourcemonitor/resourcemonitor.go
+++ b/pkg/resourcemonitor/resourcemonitor.go
@@ -493,25 +493,48 @@ func (rm *resourceMonitor) computeNUMAPlacementPayload(podRes []*podresourcesapi
 		return enc.Result()
 	}
 
+	cntsToEncode, err := GetEligibleContainersForNUMAPlacement(podRes, rm.coreIDToNodeIDMap)
+	if err != nil {
+		return numaplacement.Payload{}, err
+	}
+
+	enc.Encode(cntsToEncode...)
+	klog.V(6).InfoS("resmon: encoded containers NUMA affinity", "containers", toString(cntsToEncode))
+	return enc.Result()
+}
+
+func toString(affs []numaplacement.ContainerAffinity) string {
+	var sb strings.Builder
+	for _, aff := range affs {
+		sb.WriteString(aff.ID.String() + " -> " + strconv.Itoa(aff.NUMANode) + "\n")
+	}
+	return sb.String()
+}
+func GetEligibleContainersForNUMAPlacement(podRes []*podresourcesapi.PodResources, coreIDToNodeIDMap map[int]int) ([]numaplacement.ContainerAffinity, error) {
+	cntsToEncode := []numaplacement.ContainerAffinity{}
 	for _, pr := range podRes {
 		for _, cnt := range pr.Containers {
-			eligibleForPlacement, numaNodeID, err := numalocality.ResolveContainerPlacement(rm.coreIDToNodeIDMap, cnt)
+			eligibleForPlacement, numaNodeID, err := numalocality.ResolveContainerPlacement(coreIDToNodeIDMap, cnt)
 			if !eligibleForPlacement {
 				continue
 			}
 
 			if err != nil || numaNodeID == -1 {
-				return numaplacement.Payload{}, fmt.Errorf("failed to find NUMA node for container with exclusive resources %s. numaNodeID: %d, err: %v", cnt.Name, numaNodeID, err)
+				return []numaplacement.ContainerAffinity{}, fmt.Errorf("failed to find NUMA node for container with exclusive resources %s. numaNodeID: %d, err: %v", cnt.Name, numaNodeID, err)
 			}
 
-			enc.EncodeContainer(pr.Namespace, pr.Name, cnt.Name, numaNodeID)
-			klog.V(6).InfoS("resmon: encoded container NUMA affinity", "container", pr.Namespace+"/"+pr.Name+"/"+cnt.Name, "numaNodeID", numaNodeID)
+			cntsToEncode = append(cntsToEncode, numaplacement.ContainerAffinity{
+				ID: numaplacement.ContainerID{
+					Namespace:     pr.Namespace,
+					PodName:       pr.Name,
+					ContainerName: cnt.Name,
+				},
+				NUMANode: numaNodeID,
+			})
 		}
 	}
-	return enc.Result()
-
+	return cntsToEncode, nil
 }
-
 func computePodFingerprintFromPodResources(podRes []*podresourcesapi.PodResources, st *podfingerprint.Status, verifyFunc func(*podresourcesapi.PodResources) podresfilter.Result) (string, []*podresourcesapi.PodResources) {
 	fp := podfingerprint.NewTracingFingerprint(len(podRes), st)
 	var filteredPodRes []*podresourcesapi.PodResources

--- a/pkg/resourcemonitor/resourcemonitor.go
+++ b/pkg/resourcemonitor/resourcemonitor.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/k8stopologyawareschedwg/numaplacement"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -278,7 +280,7 @@ func (rm *resourceMonitor) Scan(excludeList ResourceExclude) (ScanResponse, erro
 		if rm.args.PodSetFingerprintMethod == podfingerprint.MethodAll {
 			podresVerify = podresfilter.VerifyAlwaysPass
 		}
-		pfpSign, _ := computePodFingerprintFromPodResources(respPodRes, &st, podresVerify)
+		pfpSign, filteredPodRes := computePodFingerprintFromPodResources(respPodRes, &st, podresVerify)
 		scanRes.Attributes = append(scanRes.Attributes, topologyv1alpha2.AttributeInfo{
 			Name:  podfingerprint.Attribute,
 			Value: pfpSign,
@@ -291,6 +293,19 @@ func (rm *resourceMonitor) Scan(excludeList ResourceExclude) (ScanResponse, erro
 		klog.V(6).Infof("resmon: pfp: %s", st.Repr())
 
 		podfingerprint.MarkCompleted(st)
+
+		metadataAttValue := ""
+		payload, err := rm.computeNUMAPlacementPayload(filteredPodRes)
+		if err != nil {
+			klog.V(2).ErrorS(err, "resmon: failed to encode container affinities")
+		} else {
+			metadataAttValue = payload.PackMetadata()
+		}
+
+		scanRes.Attributes = append(scanRes.Attributes, topologyv1alpha2.AttributeInfo{
+			Name:  numaplacement.AttributeMetadata,
+			Value: metadataAttValue,
+		})
 	}
 
 	allDevs := GetAllContainerDevices(respPodRes, rm.args.Namespace, rm.coreIDToNodeIDMap)
@@ -456,6 +471,45 @@ func (rm *resourceMonitor) updateNodeResources() error {
 	// hence, initialize capacity as allocatable
 	rm.updateDevicesCapacity()
 	return nil
+}
+
+func (rm *resourceMonitor) computeNUMAPlacementPayload(podRes []*podresourcesapi.PodResources) (numaplacement.Payload, error) {
+	if rm.args.TopologyManagerPolicy != TopologyManagerPolicySingleNUMANode {
+		klog.Infof("resmon: topology manager policy is not single-numa-node, skipping container NUMA affinity encoding")
+		return numaplacement.Payload{}, nil
+	}
+
+	if len(podRes) == 0 {
+		klog.Infof("resmon: zero filtered pod resources, skipping container NUMA affinity encoding")
+		return numaplacement.Payload{}, nil
+	}
+
+	enc, err := numaplacement.NewEncoder(len(rm.topo.Nodes))
+	if err != nil {
+		return numaplacement.Payload{}, fmt.Errorf("error creating encoder: %w", err)
+	}
+
+	if len(rm.topo.Nodes) == 1 {
+		return enc.Result()
+	}
+
+	for _, pr := range podRes {
+		for _, cnt := range pr.Containers {
+			eligibleForPlacement, numaNodeID, err := numalocality.ResolveContainerPlacement(rm.coreIDToNodeIDMap, cnt)
+			if !eligibleForPlacement {
+				continue
+			}
+
+			if err != nil || numaNodeID == -1 {
+				return numaplacement.Payload{}, fmt.Errorf("failed to find NUMA node for container with exclusive resources %s. numaNodeID: %d, err: %v", cnt.Name, numaNodeID, err)
+			}
+
+			enc.EncodeContainer(pr.Namespace, pr.Name, cnt.Name, numaNodeID)
+			klog.V(6).InfoS("resmon: encoded container NUMA affinity", "container", pr.Namespace+"/"+pr.Name+"/"+cnt.Name, "numaNodeID", numaNodeID)
+		}
+	}
+	return enc.Result()
+
 }
 
 func computePodFingerprintFromPodResources(podRes []*podresourcesapi.PodResources, st *podfingerprint.Status, verifyFunc func(*podresourcesapi.PodResources) podresfilter.Result) (string, []*podresourcesapi.PodResources) {

--- a/pkg/resourcemonitor/resourcemonitor.go
+++ b/pkg/resourcemonitor/resourcemonitor.go
@@ -278,7 +278,7 @@ func (rm *resourceMonitor) Scan(excludeList ResourceExclude) (ScanResponse, erro
 		if rm.args.PodSetFingerprintMethod == podfingerprint.MethodAll {
 			podresVerify = podresfilter.VerifyAlwaysPass
 		}
-		pfpSign := computePodFingerprintFromPodResources(respPodRes, &st, podresVerify)
+		pfpSign, _ := computePodFingerprintFromPodResources(respPodRes, &st, podresVerify)
 		scanRes.Attributes = append(scanRes.Attributes, topologyv1alpha2.AttributeInfo{
 			Name:  podfingerprint.Attribute,
 			Value: pfpSign,
@@ -458,16 +458,18 @@ func (rm *resourceMonitor) updateNodeResources() error {
 	return nil
 }
 
-func computePodFingerprintFromPodResources(podRes []*podresourcesapi.PodResources, st *podfingerprint.Status, verifyFunc func(*podresourcesapi.PodResources) podresfilter.Result) string {
+func computePodFingerprintFromPodResources(podRes []*podresourcesapi.PodResources, st *podfingerprint.Status, verifyFunc func(*podresourcesapi.PodResources) podresfilter.Result) (string, []*podresourcesapi.PodResources) {
 	fp := podfingerprint.NewTracingFingerprint(len(podRes), st)
+	var filteredPodRes []*podresourcesapi.PodResources
 	for _, pr := range podRes {
 		res := verifyFunc(pr)
 		if !res.Allow {
 			continue
 		}
 		_ = fp.AddPod(pr)
+		filteredPodRes = append(filteredPodRes, pr)
 	}
-	return fp.Sign()
+	return fp.Sign(), filteredPodRes
 }
 
 func collectPodsFromPodResources(podRes []*podresourcesapi.PodResources) string {
@@ -501,18 +503,6 @@ func GetAllContainerDevices(podRes []*podresourcesapi.PodResources, namespace st
 		}
 	}
 	return allCntRes
-}
-
-// ComputePodFingerprint is deprecated and will be unexported in a future version
-func ComputePodFingerprint(podRes []*podresourcesapi.PodResources, st *podfingerprint.Status, allowFilter func(*podresourcesapi.PodResources) bool) string {
-	fp := podfingerprint.NewTracingFingerprint(len(podRes), st)
-	for _, pr := range podRes {
-		if !allowFilter(pr) {
-			continue
-		}
-		_ = fp.AddPod(pr)
-	}
-	return fp.Sign()
 }
 
 func NormalizeContainerDevices(lh klog.Verbose, devices []*podresourcesapi.ContainerDevices, memoryBlocks []*podresourcesapi.ContainerMemory, cpuIds []int64, coreIDToNodeIDMap map[int]int) []*podresourcesapi.ContainerDevices {

--- a/pkg/resourcemonitor/resourcemonitor.go
+++ b/pkg/resourcemonitor/resourcemonitor.go
@@ -52,6 +52,8 @@ import (
 const (
 	defaultPodResourcesTimeout = 10 * time.Second
 	// obtained these values from node e2e tests : https://github.com/kubernetes/kubernetes/blob/82baa26905c94398a0d19e1b1ecf54eb8acb6029/test/e2e_node/util.go#L70
+
+	TopologyManagerPolicySingleNUMANode = "single-numa-node"
 )
 
 type ResourceExclude map[string][]string
@@ -75,6 +77,7 @@ type Args struct {
 	PodSetFingerprintStatusFile string          `json:"podSetFingerprintStatusFile,omitempty"`
 	PodExclude                  podexclude.List `json:"podExclude,omitempty"`
 	ExcludeTerminalPods         bool            `json:"excludeTerminalPods,omitempty"`
+	TopologyManagerPolicy       string          `json:"topologyManagerPolicy,omitempty"`
 }
 
 func (args Args) Clone() Args {

--- a/pkg/resourcemonitor/resourcemonitor.go
+++ b/pkg/resourcemonitor/resourcemonitor.go
@@ -275,6 +275,7 @@ func (rm *resourceMonitor) Scan(excludeList ResourceExclude) (ScanResponse, erro
 		Annotations: map[string]string{},
 	}
 
+	payload := numaplacement.Payload{}
 	if rm.args.PodSetFingerprint {
 		podresVerify := numalocality.Verify
 		if rm.args.PodSetFingerprintMethod == podfingerprint.MethodAll {
@@ -295,7 +296,7 @@ func (rm *resourceMonitor) Scan(excludeList ResourceExclude) (ScanResponse, erro
 		podfingerprint.MarkCompleted(st)
 
 		metadataAttValue := ""
-		payload, err := rm.computeNUMAPlacementPayload(filteredPodRes)
+		payload, err = rm.computeNUMAPlacementPayload(filteredPodRes)
 		if err != nil {
 			klog.V(2).ErrorS(err, "resmon: failed to encode container affinities")
 		} else {
@@ -320,6 +321,16 @@ func (rm *resourceMonitor) Scan(excludeList ResourceExclude) (ScanResponse, erro
 			Name:      makeZoneName(nodeID),
 			Type:      "Node",
 			Resources: make(topologyv1alpha2.ResourceInfoList, 0),
+		}
+
+		if payload.NUMANodes > 0 {
+			zoneVector, ok := payload.Vectors[nodeID]
+			if ok {
+				zone.Attributes = append(zone.Attributes, topologyv1alpha2.AttributeInfo{
+					Name:  numaplacement.AttributeVector,
+					Value: zoneVector,
+				})
+			}
 		}
 
 		costs, err := makeCostsPerNumaNode(rm.topo.Nodes, nodeID)

--- a/pkg/resourcemonitor/resourcemonitor_test.go
+++ b/pkg/resourcemonitor/resourcemonitor_test.go
@@ -18,6 +18,7 @@ package resourcemonitor
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 	"sort"
 	"strings"
@@ -31,6 +32,7 @@ import (
 
 	cmp "github.com/google/go-cmp/cmp"
 	ghwtopology "github.com/jaypipes/ghw/pkg/topology"
+	"github.com/k8stopologyawareschedwg/numaplacement"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -1361,6 +1363,261 @@ func TestResourcesScan(t *testing.T) {
 		})
 	})
 
+}
+
+func twoNUMANodesTopoForEncode() *ghwtopology.Info {
+	return &ghwtopology.Info{
+		Nodes: []*ghwtopology.Node{
+			{ID: 0},
+			{ID: 1},
+		},
+	}
+}
+
+func TestEncodeContainerAffinities(t *testing.T) {
+	t.Run("skips_when_topology_manager_policy_is_not_single_numa_node", func(t *testing.T) {
+		rm := &resourceMonitor{
+			args: Args{TopologyManagerPolicy: "restricted"},
+			topo: twoNUMANodesTopoForEncode(),
+		}
+		podRes := []*podresourcesapi.PodResources{
+			{
+				Namespace: "ns",
+				Name:      "pod",
+				Containers: []*podresourcesapi.ContainerResources{
+					{Name: "c", CpuIds: []int64{0}},
+				},
+			},
+		}
+		got, err := rm.computeNUMAPlacementPayload(podRes)
+		assert.NoError(t, err)
+		assert.Equal(t, numaplacement.Payload{}, got)
+	})
+
+	t.Run("skips_when_zero_filtered_pod_resources", func(t *testing.T) {
+		rm := &resourceMonitor{
+			args: Args{TopologyManagerPolicy: TopologyManagerPolicySingleNUMANode},
+			topo: twoNUMANodesTopoForEncode(),
+		}
+		got, err := rm.computeNUMAPlacementPayload(nil)
+		assert.NoError(t, err)
+		assert.Equal(t, numaplacement.Payload{}, got)
+
+		got, err = rm.computeNUMAPlacementPayload([]*podresourcesapi.PodResources{})
+		assert.NoError(t, err)
+		assert.Equal(t, numaplacement.Payload{}, got)
+	})
+
+	t.Run("new_encoder_fails_when_topology_has_zero_numa_nodes", func(t *testing.T) {
+		rm := &resourceMonitor{
+			args: Args{TopologyManagerPolicy: TopologyManagerPolicySingleNUMANode},
+			topo: &ghwtopology.Info{Nodes: []*ghwtopology.Node{}},
+		}
+		podRes := []*podresourcesapi.PodResources{
+			{
+				Namespace: "ns",
+				Name:      "pod",
+				Containers: []*podresourcesapi.ContainerResources{
+					{Name: "c", CpuIds: []int64{0}},
+				},
+			},
+		}
+		_, err := rm.computeNUMAPlacementPayload(podRes)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, numaplacement.ErrInconsistentNUMANodes))
+	})
+
+	t.Run("skips_containers_that_are_not_eligible_for_placement", func(t *testing.T) {
+		rm := &resourceMonitor{
+			args:              Args{TopologyManagerPolicy: TopologyManagerPolicySingleNUMANode},
+			topo:              twoNUMANodesTopoForEncode(),
+			coreIDToNodeIDMap: map[int]int{0: 0},
+		}
+		podRes := []*podresourcesapi.PodResources{
+			{
+				Namespace: "ns",
+				Name:      "pod",
+				Containers: []*podresourcesapi.ContainerResources{
+					{Name: "empty"},
+				},
+			},
+		}
+		got, err := rm.computeNUMAPlacementPayload(podRes)
+		assert.NoError(t, err)
+		want := numaplacement.Payload{
+			Containers:     0,
+			NUMANodes:      2,
+			BusiestNode:    0,
+			VectorEncoding: numaplacement.VectorEncodingLEB89,
+			Vectors:        map[int]string{},
+		}
+		assert.Empty(t, cmp.Diff(want, got))
+	})
+
+	t.Run("single_numa_topology_short_circuits_without_encoding_containers", func(t *testing.T) {
+		rm := &resourceMonitor{
+			args:              Args{TopologyManagerPolicy: TopologyManagerPolicySingleNUMANode},
+			topo:              &ghwtopology.Info{Nodes: []*ghwtopology.Node{{ID: 0}}},
+			coreIDToNodeIDMap: map[int]int{0: 0},
+		}
+		podRes := []*podresourcesapi.PodResources{
+			{
+				Namespace: "ns1",
+				Name:      "pod1",
+				Containers: []*podresourcesapi.ContainerResources{
+					{Name: "cnt1", CpuIds: []int64{0}},
+				},
+			},
+		}
+		got, err := rm.computeNUMAPlacementPayload(podRes)
+		assert.NoError(t, err)
+		want := numaplacement.Payload{
+			Containers:     0,
+			NUMANodes:      1,
+			BusiestNode:    0,
+			VectorEncoding: numaplacement.VectorEncodingLEB89,
+			Vectors:        map[int]string{},
+		}
+		assert.Empty(t, cmp.Diff(want, got))
+	})
+
+	t.Run("encodes_cpu_affinity", func(t *testing.T) {
+		rm := &resourceMonitor{
+			args:              Args{TopologyManagerPolicy: TopologyManagerPolicySingleNUMANode},
+			topo:              twoNUMANodesTopoForEncode(),
+			coreIDToNodeIDMap: map[int]int{0: 1},
+		}
+		podRes := []*podresourcesapi.PodResources{
+			{
+				Namespace: "ns1",
+				Name:      "pod1",
+				Containers: []*podresourcesapi.ContainerResources{
+					{Name: "cnt1", CpuIds: []int64{0}},
+				},
+			},
+		}
+		got, err := rm.computeNUMAPlacementPayload(podRes)
+		assert.NoError(t, err)
+		want := numaplacement.Payload{
+			Containers:     1,
+			NUMANodes:      2,
+			BusiestNode:    1,
+			VectorEncoding: numaplacement.VectorEncodingLEB89,
+			Vectors:        map[int]string{},
+		}
+		assert.Empty(t, cmp.Diff(want, got))
+	})
+
+	t.Run("encodes_device_topology_when_no_cpus", func(t *testing.T) {
+		rm := &resourceMonitor{
+			args:              Args{TopologyManagerPolicy: TopologyManagerPolicySingleNUMANode},
+			topo:              twoNUMANodesTopoForEncode(),
+			coreIDToNodeIDMap: map[int]int{},
+		}
+		podRes := []*podresourcesapi.PodResources{
+			{
+				Namespace: "ns1",
+				Name:      "pod1",
+				Containers: []*podresourcesapi.ContainerResources{
+					{
+						Name: "cnt1",
+						Devices: []*podresourcesapi.ContainerDevices{
+							{
+								ResourceName: "fake.io/gpu",
+								DeviceIds:    []string{"gpu0"},
+								Topology: &podresourcesapi.TopologyInfo{
+									Nodes: []*podresourcesapi.NUMANode{{ID: 0}},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		got, err := rm.computeNUMAPlacementPayload(podRes)
+		assert.NoError(t, err)
+		want := numaplacement.Payload{
+			Containers:     1,
+			NUMANodes:      2,
+			BusiestNode:    0,
+			VectorEncoding: numaplacement.VectorEncodingLEB89,
+			Vectors:        map[int]string{},
+		}
+		assert.Empty(t, cmp.Diff(want, got))
+	})
+
+	t.Run("encodes_memory_topology_when_no_cpus_or_devices", func(t *testing.T) {
+		rm := &resourceMonitor{
+			args:              Args{TopologyManagerPolicy: TopologyManagerPolicySingleNUMANode},
+			topo:              twoNUMANodesTopoForEncode(),
+			coreIDToNodeIDMap: map[int]int{},
+		}
+		podRes := []*podresourcesapi.PodResources{
+			{
+				Namespace: "ns1",
+				Name:      "pod1",
+				Containers: []*podresourcesapi.ContainerResources{
+					{
+						Name: "cnt1",
+						Memory: []*podresourcesapi.ContainerMemory{
+							{
+								MemoryType: "memory",
+								Size:       1024,
+								Topology: &podresourcesapi.TopologyInfo{
+									Nodes: []*podresourcesapi.NUMANode{{ID: 1}},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		got, err := rm.computeNUMAPlacementPayload(podRes)
+		assert.NoError(t, err)
+		want := numaplacement.Payload{
+			Containers:     1,
+			NUMANodes:      2,
+			BusiestNode:    1,
+			VectorEncoding: numaplacement.VectorEncodingLEB89,
+			Vectors:        map[int]string{},
+		}
+		assert.Empty(t, cmp.Diff(want, got))
+	})
+
+	t.Run("multiple_pods_mixed_skip_and_encode", func(t *testing.T) {
+		rm := &resourceMonitor{
+			args:              Args{TopologyManagerPolicy: TopologyManagerPolicySingleNUMANode},
+			topo:              twoNUMANodesTopoForEncode(),
+			coreIDToNodeIDMap: map[int]int{0: 0, 1: 1},
+		}
+		podRes := []*podresourcesapi.PodResources{
+			{
+				Namespace: "ns1",
+				Name:      "pod-a",
+				Containers: []*podresourcesapi.ContainerResources{
+					{Name: "skip-me"},
+					{Name: "ok", CpuIds: []int64{0}},
+				},
+			},
+			{
+				Namespace: "ns2",
+				Name:      "pod-b",
+				Containers: []*podresourcesapi.ContainerResources{
+					{Name: "ok2", CpuIds: []int64{1}},
+				},
+			},
+		}
+		got, err := rm.computeNUMAPlacementPayload(podRes)
+		assert.NoError(t, err)
+		want := numaplacement.Payload{
+			Containers:     2,
+			NUMANodes:      2,
+			BusiestNode:    0,
+			VectorEncoding: numaplacement.VectorEncodingLEB89,
+			Vectors:        map[int]string{1: "!"},
+		}
+		assert.Empty(t, cmp.Diff(want, got))
+	})
 }
 
 func getExpectedCoreToNodeMap() map[int]int {

--- a/pkg/resourcemonitor/resourcemonitor_test.go
+++ b/pkg/resourcemonitor/resourcemonitor_test.go
@@ -1620,6 +1620,143 @@ func TestEncodeContainerAffinities(t *testing.T) {
 	})
 }
 
+func TestGetEligibleContainersForNUMAPlacement(t *testing.T) {
+	t.Run("returns_only_eligible_containers", func(t *testing.T) {
+		podRes := []*podresourcesapi.PodResources{
+			{
+				Namespace: "ns1",
+				Name:      "pod-a",
+				Containers: []*podresourcesapi.ContainerResources{
+					{Name: "skip-empty"},
+					{Name: "cpu-bound", CpuIds: []int64{10}},
+					{
+						Name: "dev-bound",
+						Devices: []*podresourcesapi.ContainerDevices{
+							{
+								ResourceName: "fake.io/gpu",
+								DeviceIds:    []string{"gpu0"},
+								Topology: &podresourcesapi.TopologyInfo{
+									Nodes: []*podresourcesapi.NUMANode{{ID: 1}},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Namespace: "ns2",
+				Name:      "pod-b",
+				Containers: []*podresourcesapi.ContainerResources{
+					{
+						Name: "mem-bound",
+						Memory: []*podresourcesapi.ContainerMemory{
+							{
+								MemoryType: "memory",
+								Size:       2048,
+								Topology: &podresourcesapi.TopologyInfo{
+									Nodes: []*podresourcesapi.NUMANode{{ID: 0}},
+								},
+							},
+						},
+					},
+					{Name: "skip-empty-2"},
+				},
+			},
+		}
+
+		got, err := GetEligibleContainersForNUMAPlacement(podRes, map[int]int{10: 0})
+		assert.NoError(t, err)
+
+		want := []numaplacement.ContainerAffinity{
+			{
+				ID: numaplacement.ContainerID{
+					Namespace:     "ns1",
+					PodName:       "pod-a",
+					ContainerName: "cpu-bound",
+				},
+				NUMANode: 0,
+			},
+			{
+				ID: numaplacement.ContainerID{
+					Namespace:     "ns1",
+					PodName:       "pod-a",
+					ContainerName: "dev-bound",
+				},
+				NUMANode: 1,
+			},
+			{
+				ID: numaplacement.ContainerID{
+					Namespace:     "ns2",
+					PodName:       "pod-b",
+					ContainerName: "mem-bound",
+				},
+				NUMANode: 0,
+			},
+		}
+		assert.Empty(t, cmp.Diff(want, got))
+	})
+
+	t.Run("returns_error_when_container_is_eligible_but_numa_node_cannot_be_resolved", func(t *testing.T) {
+		podRes := []*podresourcesapi.PodResources{
+			{
+				Namespace: "ns",
+				Name:      "pod",
+				Containers: []*podresourcesapi.ContainerResources{
+					{Name: "cpu-bound", CpuIds: []int64{99}},
+				},
+			},
+		}
+
+		got, err := GetEligibleContainersForNUMAPlacement(podRes, map[int]int{})
+		assert.Error(t, err)
+		assert.Empty(t, got)
+		assert.Contains(t, err.Error(), "failed to find NUMA node for container with exclusive resources cpu-bound")
+	})
+}
+
+func TestToString(t *testing.T) {
+	t.Run("nil_slice", func(t *testing.T) {
+		assert.Equal(t, "", toString(nil))
+	})
+	t.Run("empty_slice", func(t *testing.T) {
+		assert.Equal(t, "", toString([]numaplacement.ContainerAffinity{}))
+	})
+	t.Run("single_affinity", func(t *testing.T) {
+		got := toString([]numaplacement.ContainerAffinity{
+			{
+				ID: numaplacement.ContainerID{
+					Namespace:     "ns",
+					PodName:       "pod",
+					ContainerName: "c1",
+				},
+				NUMANode: 0,
+			},
+		})
+		assert.Equal(t, "ns/pod/c1 -> 0\n", got)
+	})
+	t.Run("multiple_affinities", func(t *testing.T) {
+		got := toString([]numaplacement.ContainerAffinity{
+			{
+				ID: numaplacement.ContainerID{
+					Namespace:     "a",
+					PodName:       "p",
+					ContainerName: "x",
+				},
+				NUMANode: 1,
+			},
+			{
+				ID: numaplacement.ContainerID{
+					Namespace:     "b",
+					PodName:       "q",
+					ContainerName: "y",
+				},
+				NUMANode: 2,
+			},
+		})
+		assert.Equal(t, "a/p/x -> 1\nb/q/y -> 2\n", got)
+	})
+}
+
 func getExpectedCoreToNodeMap() map[int]int {
 	return map[int]int{
 		0:  0,

--- a/pkg/resourcemonitor/scan_test.go
+++ b/pkg/resourcemonitor/scan_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcemonitor
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"k8s.io/client-go/kubernetes/fake"
+	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
+
+	ghwtopology "github.com/jaypipes/ghw/pkg/topology"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	topologyv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+	"github.com/k8stopologyawareschedwg/numaplacement"
+	"github.com/k8stopologyawareschedwg/podfingerprint"
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podres"
+)
+
+func scanAttributeValue(attrs []topologyv1alpha2.AttributeInfo, name string) (string, bool) {
+	for i := range attrs {
+		if attrs[i].Name == name {
+			return attrs[i].Value, true
+		}
+	}
+	return "", false
+}
+
+// allocatableDevicesStub matches testTopology NUMA layout (IDs 0 and 1) used across resourcemonitor tests.
+func allocatableDevicesStub() []*podresourcesapi.ContainerDevices {
+	return []*podresourcesapi.ContainerDevices{
+		{ResourceName: "fake.io/net", DeviceIds: []string{"netAAA-0"}, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 0}}}},
+		{ResourceName: "fake.io/net", DeviceIds: []string{"netAAA-1"}, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 0}}}},
+		{ResourceName: "fake.io/net", DeviceIds: []string{"netAAA-2"}, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 0}}}},
+		{ResourceName: "fake.io/net", DeviceIds: []string{"netAAA-3"}, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 0}}}},
+		{ResourceName: "fake.io/net", DeviceIds: []string{"netBBB-0"}, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}},
+		{ResourceName: "fake.io/net", DeviceIds: []string{"netBBB-1"}, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}},
+		{ResourceName: "fake.io/gpu", DeviceIds: []string{"gpuAAA"}, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}},
+	}
+}
+
+func TestScan_NumaplacementMetadataWhenContainerAffinityEncoded(t *testing.T) {
+	fakeTopo := ghwtopology.Info{}
+	assert.NoError(t, json.Unmarshal([]byte(testTopology), &fakeTopo))
+
+	mockCli := new(podres.MockPodResourcesListerClient)
+	mockCli.On("GetAllocatableResources", mock.Anything, mock.Anything).Return(
+		&podresourcesapi.AllocatableResourcesResponse{
+			Devices: allocatableDevicesStub(),
+			CpuIds:  []int64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
+		}, nil)
+
+	listResp := &podresourcesapi.ListPodResourcesResponse{
+		PodResources: []*podresourcesapi.PodResources{
+			{
+				Namespace: "ns1",
+				Name:      "pod-a",
+				Containers: []*podresourcesapi.ContainerResources{
+					{Name: "c1", CpuIds: []int64{0}},
+				},
+			},
+			{
+				Namespace: "ns2",
+				Name:      "pod-b",
+				Containers: []*podresourcesapi.ContainerResources{
+					{Name: "c2", CpuIds: []int64{1}},
+				},
+			},
+		},
+	}
+	mockCli.On("List", mock.Anything, mock.Anything).Return(listResp, nil)
+
+	rm, err := NewResourceMonitor(Handle{PodResCli: mockCli}, Args{
+		PodSetFingerprint:       true,
+		PodSetFingerprintMethod: podfingerprint.MethodAll,
+		TopologyManagerPolicy:   TopologyManagerPolicySingleNUMANode,
+	}, WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
+	assert.NoError(t, err)
+
+	scanRes, err := rm.Scan(ResourceExclude{})
+	assert.NoError(t, err)
+
+	metaVal, ok := scanAttributeValue(scanRes.Attributes, numaplacement.AttributeMetadata)
+	assert.True(t, ok, "expected %q from encoded container NUMA affinities", numaplacement.AttributeMetadata)
+	assert.True(t, strings.HasPrefix(metaVal, numaplacement.Prefix+numaplacement.Version))
+	assert.Contains(t, metaVal, "cc=")
+	assert.Contains(t, metaVal, "nn=")
+
+	mockCli.AssertExpectations(t)
+}
+
+func TestScan_NumaplacementMetadataEmptyWhenEncodeFails(t *testing.T) {
+	fakeTopo := ghwtopology.Info{}
+	assert.NoError(t, json.Unmarshal([]byte(testTopology), &fakeTopo))
+
+	mockCli := new(podres.MockPodResourcesListerClient)
+	mockCli.On("GetAllocatableResources", mock.Anything, mock.Anything).Return(
+		&podresourcesapi.AllocatableResourcesResponse{
+			Devices: allocatableDevicesStub(),
+			CpuIds:  []int64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
+		}, nil)
+
+	// CpuIds [999] is not in MakeCoreIDToNodeIDMap(testTopology) -> encodeContainerAffinities errors; metadata value stays empty.
+	listResp := &podresourcesapi.ListPodResourcesResponse{
+		PodResources: []*podresourcesapi.PodResources{
+			{
+				Namespace: "ns",
+				Name:      "pod",
+				Containers: []*podresourcesapi.ContainerResources{
+					{Name: "bad", CpuIds: []int64{999}},
+				},
+			},
+		},
+	}
+	mockCli.On("List", mock.Anything, mock.Anything).Return(listResp, nil)
+
+	rm, err := NewResourceMonitor(Handle{PodResCli: mockCli}, Args{
+		PodSetFingerprint:       true,
+		PodSetFingerprintMethod: podfingerprint.MethodAll,
+		TopologyManagerPolicy:   TopologyManagerPolicySingleNUMANode,
+	}, WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
+	assert.NoError(t, err)
+
+	scanRes, err := rm.Scan(ResourceExclude{})
+	assert.NoError(t, err)
+
+	metaVal, ok := scanAttributeValue(scanRes.Attributes, numaplacement.AttributeMetadata)
+	assert.True(t, ok)
+	assert.Equal(t, "", metaVal)
+
+	mockCli.AssertExpectations(t)
+}
+
+func TestScan_NoNumaplacementMetadataWithoutPodSetFingerprint(t *testing.T) {
+	fakeTopo := ghwtopology.Info{}
+	assert.NoError(t, json.Unmarshal([]byte(testTopology), &fakeTopo))
+
+	mockCli := new(podres.MockPodResourcesListerClient)
+	mockCli.On("GetAllocatableResources", mock.Anything, mock.Anything).Return(
+		&podresourcesapi.AllocatableResourcesResponse{
+			Devices: allocatableDevicesStub(),
+			CpuIds:  []int64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
+		}, nil)
+	mockCli.On("List", mock.Anything, mock.Anything).Return(
+		&podresourcesapi.ListPodResourcesResponse{PodResources: []*podresourcesapi.PodResources{}}, nil)
+
+	rm, err := NewResourceMonitor(Handle{PodResCli: mockCli}, Args{PodSetFingerprint: false}, WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
+	assert.NoError(t, err)
+
+	scanRes, err := rm.Scan(ResourceExclude{})
+	assert.NoError(t, err)
+
+	_, ok := scanAttributeValue(scanRes.Attributes, numaplacement.AttributeMetadata)
+	assert.False(t, ok)
+
+	mockCli.AssertExpectations(t)
+}

--- a/pkg/resourcemonitor/scan_test.go
+++ b/pkg/resourcemonitor/scan_test.go
@@ -18,6 +18,7 @@ package resourcemonitor
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -68,19 +69,103 @@ func TestScan_NumaplacementMetadataWhenContainerAffinityEncoded(t *testing.T) {
 		}, nil)
 
 	listResp := &podresourcesapi.ListPodResourcesResponse{
+		// mimics the pod resources that are reported by the kubelet for single-numa-node topology
+		// and it's valid to have multiple containers in a pod with the different NUMA node affinity
+		// simulating container topology scope
 		PodResources: []*podresourcesapi.PodResources{
+			// Guaranteed-like: exclusive CPUs.
+			// eligible for numaplacement container encoding
 			{
-				Namespace: "ns1",
-				Name:      "pod-a",
+				Namespace: "guaranteed-ns",
+				Name:      "pod1",
 				Containers: []*podresourcesapi.ContainerResources{
-					{Name: "c1", CpuIds: []int64{0}},
+					{
+						Name:   "app",
+						CpuIds: []int64{2},
+						Memory: []*podresourcesapi.ContainerMemory{
+							{
+								MemoryType: "memory",
+								Size:       1024,
+								Topology: &podresourcesapi.TopologyInfo{
+									Nodes: []*podresourcesapi.NUMANode{{ID: 0}},
+								},
+							},
+						},
+					},
+					{
+						Name:   "app-2",
+						CpuIds: []int64{4},
+						Memory: []*podresourcesapi.ContainerMemory{
+							{
+								MemoryType: "memory",
+								Size:       1024,
+								Topology: &podresourcesapi.TopologyInfo{
+									Nodes: []*podresourcesapi.NUMANode{{ID: 0}},
+								},
+							},
+						},
+					},
 				},
 			},
+			// Burstable/BestEffort-like: multiple containers; only sidecar has a NUMA-local device and are eligible for numaplacement container encoding.
 			{
-				Namespace: "ns2",
-				Name:      "pod-b",
+				Namespace: "burst-ns",
+				Name:      "pod2",
 				Containers: []*podresourcesapi.ContainerResources{
-					{Name: "c2", CpuIds: []int64{1}},
+					{Name: "app-shim"},
+					{
+						Name: "sidecar",
+						Devices: []*podresourcesapi.ContainerDevices{
+							{
+								ResourceName: "fake.io/gpu",
+								DeviceIds:    []string{"gpuAAA"},
+								Topology: &podresourcesapi.TopologyInfo{
+									Nodes: []*podresourcesapi.NUMANode{{ID: 1}},
+								},
+							},
+						},
+					},
+				},
+			},
+			// BestEffort/Burstable-like without non-native resources
+			// not eligible for numaplacement container encoding
+			{
+				Namespace: "be-ns",
+				Name:      "pod3",
+				Containers: []*podresourcesapi.ContainerResources{
+					{Name: "c1"},
+					{Name: "c2"},
+				},
+			},
+			// Guaranteed-like with NUMA-local memory (no integer CPUs) - eligible for numaplacement container encoding
+			{
+				Namespace: "mem-ns",
+				Name:      "pod4",
+				Containers: []*podresourcesapi.ContainerResources{
+					{
+						Name: "cnt-mem-1",
+						Memory: []*podresourcesapi.ContainerMemory{
+							{
+								MemoryType: "memory",
+								Size:       1024,
+								Topology: &podresourcesapi.TopologyInfo{
+									Nodes: []*podresourcesapi.NUMANode{{ID: 1}},
+								},
+							},
+						},
+					},
+					{
+						Name: "cnt-mem-2",
+						Memory: []*podresourcesapi.ContainerMemory{
+							{
+								MemoryType: "memory",
+								Size:       1024,
+								Topology: &podresourcesapi.TopologyInfo{
+									Nodes: []*podresourcesapi.NUMANode{{ID: 0}},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
@@ -94,15 +179,79 @@ func TestScan_NumaplacementMetadataWhenContainerAffinityEncoded(t *testing.T) {
 	}, WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
 	assert.NoError(t, err)
 
+	// Build container affinities which belong to NUMA node 0 from listResp.
+	expectedEligibleContainers := []numaplacement.ContainerAffinity{
+		{
+			ID: numaplacement.ContainerID{
+				Namespace:     "guaranteed-ns",
+				PodName:       "pod1",
+				ContainerName: "app",
+			},
+			NUMANode: 0,
+		},
+		{
+			ID: numaplacement.ContainerID{
+				Namespace:     "guaranteed-ns",
+				PodName:       "pod1",
+				ContainerName: "app-2",
+			},
+			NUMANode: 0,
+		},
+		{
+			ID: numaplacement.ContainerID{
+				Namespace:     "burst-ns",
+				PodName:       "pod2",
+				ContainerName: "sidecar",
+			},
+			NUMANode: 1,
+		},
+		{
+			ID: numaplacement.ContainerID{
+				Namespace:     "mem-ns",
+				PodName:       "pod4",
+				ContainerName: "cnt-mem-1",
+			},
+			NUMANode: 1,
+		},
+		{
+			ID: numaplacement.ContainerID{
+				Namespace:     "mem-ns",
+				PodName:       "pod4",
+				ContainerName: "cnt-mem-2",
+			},
+			NUMANode: 0,
+		},
+	}
+	eligibleContainers, err := GetEligibleContainersForNUMAPlacement(listResp.PodResources, rm.coreIDToNodeIDMap)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedEligibleContainers, eligibleContainers)
+
+	expectedPayload, err := rm.computeNUMAPlacementPayload(listResp.PodResources)
+	assert.NoError(t, err)
+
+	expectedVectorForNUMA1 := expectedPayload.Vectors[1] // Vectors is a map of numa ID -> vector
+	fmt.Println("expectedVectorForNUMA1", expectedVectorForNUMA1)
 	scanRes, err := rm.Scan(ResourceExclude{})
 	assert.NoError(t, err)
 
 	metaVal, ok := scanAttributeValue(scanRes.Attributes, numaplacement.AttributeMetadata)
 	assert.True(t, ok, "expected %q from encoded container NUMA affinities", numaplacement.AttributeMetadata)
 	assert.True(t, strings.HasPrefix(metaVal, numaplacement.Prefix+numaplacement.Version))
-	assert.Contains(t, metaVal, "cc=")
-	assert.Contains(t, metaVal, "nn=")
+	assert.Contains(t, metaVal, "cc=5")
+	assert.Contains(t, metaVal, "nn=2")
+	assert.Contains(t, metaVal, "bn=0")
 
+	for _, zone := range scanRes.Zones {
+		if zone.Name == "node-0" {
+			_, ok := scanAttributeValue(zone.Attributes, numaplacement.AttributeVector)
+			assert.False(t, ok) // because it's the busiest NUMA
+		}
+		if zone.Name == "node-1" {
+			vectorVal, ok := scanAttributeValue(zone.Attributes, numaplacement.AttributeVector)
+			assert.True(t, ok)
+			assert.Equal(t, expectedVectorForNUMA1, vectorVal)
+		}
+	}
 	mockCli.AssertExpectations(t)
 }
 

--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -27,7 +27,10 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
+	"github.com/k8stopologyawareschedwg/numaplacement"
+
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	clientset "k8s.io/client-go/kubernetes"
@@ -257,6 +260,149 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 				dumpPods(f.K8SCli, topologyUpdaterNode.Name, errMessage)
 			}
 			gomega.Expect(pfpChanged).To(gomega.BeTrue(), errMessage)
+		})
+
+		// Node-level numaplacement.AttributeMetadata is published when pod fingerprinting is enabled; it holds
+		// PackMetadata() from encoded container NUMA affinities (see resourcemonitor Scan + encodeContainerAffinities).
+		// It is not a per-zone field; on single-NUMA nodes the encoder short-circuits and the value may stay empty
+		// or unchanged when pods change.
+		ginkgo.Context("[numaplacement] node-level container affinity metadata", func() {
+			ginkgo.It("should remain stable while workloads are unchanged", func() {
+				prevNrt := e2enodetopology.GetNodeTopology(f.TopoCli, topologyUpdaterNode.Name)
+				klog.Infof("Initial NRT: %q generation=%v resourceVersion=%v", prevNrt.Name, prevNrt.Generation, prevNrt.ResourceVersion)
+
+				if _, ok := findAttribute(prevNrt.Attributes, podfingerprint.Attribute); !ok {
+					ginkgo.Skip("pod fingerprinting attribute not found - assuming disabled")
+				}
+				metaBefore, ok := findAttribute(prevNrt.Attributes, numaplacement.AttributeMetadata)
+				if !ok {
+					ginkgo.Skip("numaplacement metadata attribute not found - RTE may not expose container NUMA affinity encoding")
+				}
+
+				dumpPods(f.K8SCli, topologyUpdaterNode.Name, "reference pods")
+
+				updateInterval, method, err := estimateUpdateInterval(*prevNrt)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				klog.Infof("%s update interval: %s", method, updateInterval)
+
+				maxSteps := 3
+				for step := 0; step < maxSteps; step++ {
+					klog.Infof("waiting for %s: %d/%d", updateInterval, step+1, maxSteps)
+					time.Sleep(updateInterval)
+				}
+
+				// note we don't test no pods have been added/deleted. This is because the suite is supposed to own the cluster while it runs
+				// IOW, if we don't create/delete pods explicitly, noone else is supposed to do
+				currNrt := e2enodetopology.GetNodeTopology(f.TopoCli, topologyUpdaterNode.Name)
+				klog.Infof("Current NRT: %q generation=%v resourceVersion=%v", currNrt.Name, currNrt.Generation, currNrt.ResourceVersion)
+
+				metaAfter, ok := findAttribute(currNrt.Attributes, numaplacement.AttributeMetadata)
+				gomega.Expect(ok).To(gomega.BeTrue(), "attribute %q missing after wait", numaplacement.AttributeMetadata)
+
+				if metaBefore != metaAfter {
+					dumpPods(f.K8SCli, topologyUpdaterNode.Name, "after numaplacement metadata mismatch")
+					_ = dumpRTELogs(f.K8SCli, topologyUpdaterNode.Name)
+				}
+
+				gomega.Expect(metaAfter).To(gomega.Equal(metaBefore), "numaplacement metadata attribute changed unexpectedly")
+			})
+
+			ginkgo.It("should use the packed metadata prefix when the value is non-empty", func() {
+				nrt := e2enodetopology.GetNodeTopology(f.TopoCli, topologyUpdaterNode.Name)
+				if _, ok := findAttribute(nrt.Attributes, podfingerprint.Attribute); !ok {
+					ginkgo.Skip("pod fingerprinting attribute not found - assuming disabled")
+				}
+				meta, ok := findAttribute(nrt.Attributes, numaplacement.AttributeMetadata)
+				if !ok {
+					ginkgo.Skip("numaplacement metadata attribute not found")
+				}
+				gomega.Expect(meta).ToNot(gomega.BeEmpty(), "numaplacement metadata is empty")
+				gomega.Expect(meta).To(gomega.HavePrefix(numaplacement.Prefix + numaplacement.Version))
+			})
+
+			ginkgo.DescribeTable("numaplacement metadata on multi-NUMA nodes when pods are added and removed",
+				func(qos corev1.PodQOSClass, resources corev1.ResourceList, expectPlacementMetadataChange bool) {
+					for resName, resQty := range resources {
+						nodes, err := e2enodes.FilterNodesWithEnoughResource(workerNodes, resName, resQty)
+						gomega.Expect(err).ToNot(gomega.HaveOccurred())
+						if len(nodes) < 1 {
+							ginkgo.Skip("not enough allocatable resources for this test")
+						}
+					}
+
+					prevNrt := e2enodetopology.GetNodeTopology(f.TopoCli, topologyUpdaterNode.Name)
+					if _, ok := findAttribute(prevNrt.Attributes, podfingerprint.Attribute); !ok {
+						ginkgo.Skip("pod fingerprinting attribute not found - assuming disabled")
+					}
+					metaBefore, ok := findAttribute(prevNrt.Attributes, numaplacement.AttributeMetadata)
+					if !ok {
+						ginkgo.Skip("numaplacement metadata attribute not found")
+					}
+					if len(prevNrt.Zones) < 2 {
+						ginkgo.Skip("single NUMA zone in NRT: affinity encoding does not vary with pod set (encoder short-circuit)")
+					}
+
+					dumpPods(f.K8SCli, topologyUpdaterNode.Name, "reference pods")
+
+					updateInterval, method, err := estimateUpdateInterval(*prevNrt)
+					gomega.Expect(err).ToNot(gomega.HaveOccurred())
+					klog.Infof("%s update interval: %s", method, updateInterval)
+
+					sleeperPod := e2epods.MakeSleeperPod(qos, resources)
+					pod, err := e2epods.CreateSync(f, sleeperPod)
+					gomega.Expect(err).ToNot(gomega.HaveOccurred())
+					podNamespace, podName := pod.Namespace, pod.Name
+					ginkgo.DeferCleanup(e2epods.DeletePodSyncByName, f, podNamespace, podName)
+
+					withPodNrt := getUpdatedNRT(f.TopoCli, topologyUpdaterNode.Name, *prevNrt, updateInterval)
+					metaWithPod, ok := findAttribute(withPodNrt.Attributes, numaplacement.AttributeMetadata)
+					gomega.Expect(ok).To(gomega.BeTrue(), "attribute %q missing after pod creation", numaplacement.AttributeMetadata)
+
+					if expectPlacementMetadataChange {
+						if metaWithPod == metaBefore {
+							dumpPods(f.K8SCli, topologyUpdaterNode.Name, "metadata unchanged after pod creation")
+							_ = dumpRTELogs(f.K8SCli, topologyUpdaterNode.Name)
+						}
+						gomega.Expect(metaWithPod).ToNot(gomega.Equal(metaBefore), "numaplacement metadata did not change after a workload with exclusive CPU placement was scheduled")
+					} else {
+						if metaWithPod != metaBefore {
+							dumpPods(f.K8SCli, topologyUpdaterNode.Name, "metadata changed unexpectedly for workload without exclusive CPU")
+							_ = dumpRTELogs(f.K8SCli, topologyUpdaterNode.Name)
+						}
+						gomega.Expect(metaWithPod).To(gomega.Equal(metaBefore), "numaplacement metadata should stay unchanged for workloads that do not get exclusive CPUs in the pod-resources API")
+					}
+
+					err = e2epods.DeletePodSyncByName(f, podNamespace, podName)
+					gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+					afterDeleteNrt := getUpdatedNRT(f.TopoCli, topologyUpdaterNode.Name, *withPodNrt, updateInterval)
+					metaAfter, ok := findAttribute(afterDeleteNrt.Attributes, numaplacement.AttributeMetadata)
+					gomega.Expect(ok).To(gomega.BeTrue())
+					if metaAfter != metaBefore {
+						dumpPods(f.K8SCli, topologyUpdaterNode.Name, "metadata mismatch after pod deletion")
+						_ = dumpRTELogs(f.K8SCli, topologyUpdaterNode.Name)
+					}
+					gomega.Expect(metaAfter).To(gomega.Equal(metaBefore), "numaplacement metadata should return to baseline after pod removal")
+				},
+				ginkgo.Entry("guaranteed pod", corev1.PodQOSGuaranteed, corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1000m"),
+					corev1.ResourceMemory: resource.MustParse("250Mi"),
+				}, true),
+				ginkgo.Entry("burstable pod - nothing exclusive", corev1.PodQOSBurstable, corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1000m"),
+					corev1.ResourceMemory: resource.MustParse("250Mi"),
+				}, false),
+				ginkgo.Entry("burstable pod - exclusive device", corev1.PodQOSBurstable, corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1000m"),
+					corev1.ResourceName(e2etestenv.GetDeviceName()): resource.MustParse("1"),
+				}, true),
+				ginkgo.Entry("best effort pod - nothing exclusive", corev1.PodQOSBestEffort,
+					corev1.ResourceList{}, false),
+				ginkgo.Entry("best effort pod - exclusive device", corev1.PodQOSBestEffort,
+					corev1.ResourceList{
+						corev1.ResourceName(e2etestenv.GetDeviceName()): resource.MustParse("1"),
+					}, true),
+			)
 		})
 	})
 	ginkgo.Context("with refresh-node-resources enabled", func() {

--- a/test/e2e/topology_updater/topology_updater.go
+++ b/test/e2e/topology_updater/topology_updater.go
@@ -123,7 +123,7 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 			ginkgo.By("getting the initial topology information")
 			initialNodeTopo := e2enodetopology.GetNodeTopologyWithResource(f.TopoCli, topologyUpdaterNode.Name, devName)
 			ginkgo.By("creating a pod consuming resources from the shared, non-exclusive CPU pool (best-effort QoS)")
-			sleeperPod := e2epods.MakeBestEffortSleeperPod()
+			sleeperPod := e2epods.MakeSleeperPod(corev1.PodQOSBestEffort, corev1.ResourceList{})
 
 			pod, err := e2epods.CreateSync(f, sleeperPod)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())

--- a/test/e2e/utils/nodes/nodes.go
+++ b/test/e2e/utils/nodes/nodes.go
@@ -95,6 +95,30 @@ func FilterNodesWithEnoughCores(nodes []corev1.Node, cpuAmount string) ([]corev1
 	return resNodes, nil
 }
 
+func FilterNodesWithEnoughResource(nodes []corev1.Node, resourceName corev1.ResourceName, resourceAmount resource.Quantity) ([]corev1.Node, error) {
+	klog.Infof("checking request %v on %d nodes", resourceAmount.String(), len(nodes))
+
+	resNodes := []corev1.Node{}
+	for _, node := range nodes {
+		availResource, ok := node.Status.Allocatable[corev1.ResourceName(resourceName)]
+		if !ok || availResource.IsZero() {
+			klog.Infof("node %q has no allocatable %q", node.Name, resourceName)
+			continue
+		}
+
+		if availResource.Cmp(resourceAmount) < 1 {
+			klog.Infof("node %q available %q %v requested %v", node.Name, resourceName, availResource.String(), resourceAmount.String())
+			continue
+		}
+
+		// TODO account for node base load
+		klog.Infof("node %q has enough resources, cluster OK", node.Name)
+		resNodes = append(resNodes, node)
+	}
+
+	return resNodes, nil
+}
+
 // LabelNode will add new set of labels to a given node
 func LabelNode(cs kubernetes.Interface, node *corev1.Node, newLabels map[string]string) error {
 	labelsMap := make(map[string]string)

--- a/test/e2e/utils/pods/pods.go
+++ b/test/e2e/utils/pods/pods.go
@@ -42,44 +42,23 @@ const (
 )
 
 func MakeGuaranteedSleeperPod(cpuLimit string) *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "sleeper-gu-pod",
-		},
-		Spec: corev1.PodSpec{
-			NodeSelector:  map[string]string{e2etestconsts.TestNodeLabel: ""},
-			RestartPolicy: corev1.RestartPolicyNever,
-			Containers: []corev1.Container{
-				{
-					Name:  "sleeper-gu-cnt",
-					Image: CentosImage,
-					// 1 hour (or >= 1h in general) is "forever" for our purposes
-					Command: []string{"/bin/sleep", "1h"},
-					Resources: corev1.ResourceRequirements{
-						Limits: corev1.ResourceList{
-							// we use 1 core because that's the minimal meaningful quantity
-							corev1.ResourceName(corev1.ResourceCPU): resource.MustParse(cpuLimit),
-							// any random reasonable amount is fine
-							corev1.ResourceName(corev1.ResourceMemory): resource.MustParse("100Mi"),
-						},
-					},
-				},
-			},
-		},
-	}
+	return MakeSleeperPod(corev1.PodQOSGuaranteed, corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse(cpuLimit),
+		corev1.ResourceMemory: resource.MustParse("100Mi"),
+	})
 }
 
-func MakeBestEffortSleeperPod() *corev1.Pod {
-	return &corev1.Pod{
+func MakeSleeperPod(qos corev1.PodQOSClass, resources corev1.ResourceList) *corev1.Pod {
+	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "sleeper-be-pod",
+			Name: "sleeper-pod",
 		},
 		Spec: corev1.PodSpec{
 			NodeSelector:  map[string]string{e2etestconsts.TestNodeLabel: ""},
 			RestartPolicy: corev1.RestartPolicyNever,
 			Containers: []corev1.Container{
 				{
-					Name:  "sleeper-be-cnt",
+					Name:  "sleeper-cnt",
 					Image: CentosImage,
 					// 1 hour (or >= 1h in general) is "forever" for our purposes
 					Command: []string{"/bin/sleep", "1h"},
@@ -87,6 +66,20 @@ func MakeBestEffortSleeperPod() *corev1.Pod {
 			},
 		},
 	}
+
+	if qos == corev1.PodQOSBestEffort {
+		return pod
+	}
+
+	pod.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+		Requests: resources,
+	}
+	if qos == corev1.PodQOSBurstable {
+		return pod
+	}
+
+	pod.Spec.Containers[0].Resources.Limits = resources
+	return pod
 }
 
 func DeletePodSyncByName(f *fixture.Fixture, podNamespace, podName string) error {


### PR DESCRIPTION
Populate numaplacement.AttributeMetadata from encoded container affinities
alongside existing pod fingerprint attributes when enabled.

Please see the commits for detailed steps to enable this. 