### PR TITLE
podreadiness: optimize condition injection

### DIFF
--- a/pkg/podreadiness/conditioninjector.go
+++ b/pkg/podreadiness/conditioninjector.go
@@ -35,9 +35,9 @@ func NewConditionInjector(cs kubernetes.Interface) (*ConditionInjector, error) {
 	}, nil
 }
 
-func (ci *ConditionInjector) Inject(cond v1.PodCondition) error {
+func (ci *ConditionInjector) Inject(ctx context.Context, cond v1.PodCondition) error {
 	conditionExist := false
-	pod, err := ci.cs.CoreV1().Pods(ci.ns).Get(context.TODO(), ci.podName, metav1.GetOptions{})
+	pod, err := ci.cs.CoreV1().Pods(ci.ns).Get(ctx, ci.podName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -62,18 +62,20 @@ func (ci *ConditionInjector) Inject(cond v1.PodCondition) error {
 
 	klog.V(4).Infof("pod conditions: %v", pod.Status.Conditions)
 
-	_, err = ci.cs.CoreV1().Pods(ci.ns).UpdateStatus(context.TODO(), pod, metav1.UpdateOptions{})
+	_, err = ci.cs.CoreV1().Pods(ci.ns).UpdateStatus(ctx, pod, metav1.UpdateOptions{})
 	return err
 }
 
-func (ci *ConditionInjector) Run(condChan <-chan v1.PodCondition) {
-	go func() {
-		for {
-			cond := <-condChan
-			err := ci.Inject(cond)
+func (ci *ConditionInjector) Run(ctx context.Context, condChan <-chan v1.PodCondition) {
+	for {
+		select {
+		case cond := <-condChan:
+			err := ci.Inject(ctx, cond)
 			if err != nil {
 				klog.Errorf("failed to update pod status with condition: %v", cond)
 			}
+		case <-ctx.Done():
+			return
 		}
-	}()
+	}
 }

--- a/pkg/podreadiness/conditioninjector.go
+++ b/pkg/podreadiness/conditioninjector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,9 +13,19 @@ import (
 )
 
 type ConditionInjector struct {
-	cs      kubernetes.Interface
-	ns      string
-	podName string
+	cs         kubernetes.Interface
+	ns         string
+	podName    string
+	lastUpdate map[v1.PodConditionType]v1.PodCondition
+}
+
+func NewConditionInjectorWithIdentity(cs kubernetes.Interface, ns, podName string) *ConditionInjector {
+	return &ConditionInjector{
+		cs:         cs,
+		ns:         ns,
+		podName:    podName,
+		lastUpdate: make(map[v1.PodConditionType]v1.PodCondition),
+	}
 }
 
 func NewConditionInjector(cs kubernetes.Interface) (*ConditionInjector, error) {
@@ -27,43 +38,42 @@ func NewConditionInjector(cs kubernetes.Interface) (*ConditionInjector, error) {
 	if !ok {
 		return nil, fmt.Errorf("the env REFERENCE_POD_NAME doesn't exist")
 	}
-
-	return &ConditionInjector{
-		cs:      cs,
-		ns:      nsVal,
-		podName: podVal,
-	}, nil
+	return NewConditionInjectorWithIdentity(cs, nsVal, podVal), nil
 }
 
 func (ci *ConditionInjector) Inject(ctx context.Context, cond v1.PodCondition) error {
-	conditionExist := false
+	if oldCond, ok := ci.lastUpdate[cond.Type]; ok && equalPodCondition(oldCond, cond) {
+		// avoid APIServer round trips if nothing changed
+		return nil
+	}
+
 	pod, err := ci.cs.CoreV1().Pods(ci.ns).Get(ctx, ci.podName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
 
-	for pos, podCond := range pod.Status.Conditions {
-		if podCond.Type == cond.Type {
-			conditionExist = true
-			if podCond.Status == cond.Status {
-				// do nothing condition already updated
-				return nil
-			}
-			// update the condition
-			pod.Status.Conditions[pos] = cond
-		}
+	pos := slices.IndexFunc(pod.Status.Conditions, func(c v1.PodCondition) bool {
+		return c.Type == cond.Type
+	})
+	if pos >= 0 {
+		// note this cause an unnecessary update on RTE restart at steady state.
+		// we can re-update conditions with the existing value because of that.
+		// we expect RTE restarts to be rare, so we tolerate this extra write
+		// for now.
+		pod.Status.Conditions[pos] = cond
+		klog.V(4).Infof("updated conditions inplace: %v", pod.Status.Conditions)
+	} else {
+		pod.Status.Conditions = append(pod.Status.Conditions, cond)
+		klog.V(4).Infof("updated conditions adding: %v", pod.Status.Conditions)
 	}
-
-	if !conditionExist {
-		conds := pod.Status.Conditions
-		conds = append(conds, cond)
-		pod.Status.Conditions = conds
-	}
-
-	klog.V(4).Infof("pod conditions: %v", pod.Status.Conditions)
 
 	_, err = ci.cs.CoreV1().Pods(ci.ns).UpdateStatus(ctx, pod, metav1.UpdateOptions{})
-	return err
+	if err != nil {
+		return err
+	}
+
+	ci.lastUpdate[cond.Type] = cond
+	return nil
 }
 
 func (ci *ConditionInjector) Run(ctx context.Context, condChan <-chan v1.PodCondition) {
@@ -78,4 +88,8 @@ func (ci *ConditionInjector) Run(ctx context.Context, condChan <-chan v1.PodCond
 			return
 		}
 	}
+}
+
+func equalPodCondition(a, b v1.PodCondition) bool {
+	return a.Type == b.Type && a.Status == b.Status && a.Reason == b.Reason && a.Message == b.Message
 }

--- a/pkg/podreadiness/conditioninjector_test.go
+++ b/pkg/podreadiness/conditioninjector_test.go
@@ -1,0 +1,356 @@
+package podreadiness
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestEqualPodCondition(t *testing.T) {
+	baseCond := makeBaseCondition()
+
+	testCases := []struct {
+		name     string
+		a, b     v1.PodCondition
+		expected bool
+	}{
+		{
+			name:     "identical conditions",
+			a:        *baseCond.DeepCopy(),
+			b:        *baseCond.DeepCopy(),
+			expected: true,
+		},
+		{
+			name:     "different LastTransitionTime",
+			a:        *baseCond.DeepCopy(),
+			b:        makeBaseCondition(),
+			expected: true,
+		},
+		{
+			name: "different LastProbeTime",
+			a:    *baseCond.DeepCopy(),
+			b: v1.PodCondition{
+				Type:          baseCond.Type,
+				Status:        baseCond.Status,
+				Reason:        baseCond.Reason,
+				Message:       baseCond.Message,
+				LastProbeTime: metav1.Time{Time: time.Now().Add(10 * time.Second)},
+			},
+			expected: true,
+		},
+		{
+			name: "different Status",
+			a:    *baseCond.DeepCopy(),
+			b: v1.PodCondition{
+				Type:    baseCond.Type,
+				Status:  v1.ConditionFalse,
+				Reason:  baseCond.Reason,
+				Message: baseCond.Message,
+			},
+			expected: false,
+		},
+		{
+			name: "different Type",
+			a:    *baseCond.DeepCopy(),
+			b: v1.PodCondition{
+				Type:    v1.PodConditionType(NodeTopologyUpdated),
+				Status:  baseCond.Status,
+				Reason:  baseCond.Reason,
+				Message: baseCond.Message,
+			},
+			expected: false,
+		},
+		{
+			name: "different Reason",
+			a:    *baseCond.DeepCopy(),
+			b: v1.PodCondition{
+				Type:    baseCond.Type,
+				Status:  baseCond.Status,
+				Reason:  "ScanFailed",
+				Message: baseCond.Message,
+			},
+			expected: false,
+		},
+		{
+			name: "different Message",
+			a:    *baseCond.DeepCopy(),
+			b: v1.PodCondition{
+				Type:    baseCond.Type,
+				Status:  baseCond.Status,
+				Reason:  baseCond.Reason,
+				Message: "something else happened",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := equalPodCondition(tc.a, tc.b)
+			if got != tc.expected {
+				t.Errorf("equalPodCondition() = %v, expected %v", got, tc.expected)
+			}
+		})
+	}
+}
+
+const (
+	testNS      = "test-ns"
+	testPodName = "test-pod"
+)
+
+func TestInject_CacheHit(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testPodName,
+			Namespace: testNS,
+		},
+	}
+
+	cs := fake.NewSimpleClientset(pod)
+	ci := NewConditionInjectorWithIdentity(cs, pod.Namespace, pod.Name)
+
+	cond := v1.PodCondition{
+		Type:               v1.PodConditionType(PodresourcesFetched),
+		Status:             v1.ConditionTrue,
+		LastTransitionTime: metav1.Time{Time: time.Now()},
+	}
+
+	ctx := context.Background()
+
+	// First call: cache is empty, should hit the API (get + update-status)
+	if err := ci.Inject(ctx, cond); err != nil {
+		t.Fatalf("first Inject failed: %v", err)
+	}
+
+	checkAPIServerUpdated(t, cs.Actions())
+
+	cs.ClearActions()
+
+	// Second call: same condition (different timestamp), cache should short-circuit
+	cond2 := v1.PodCondition{
+		Type:               v1.PodConditionType(PodresourcesFetched),
+		Status:             v1.ConditionTrue,
+		LastTransitionTime: metav1.Time{Time: time.Now().Add(10 * time.Second)},
+	}
+
+	if err := ci.Inject(ctx, cond2); err != nil {
+		t.Fatalf("second Inject failed: %v", err)
+	}
+
+	checkNoAPICalls(t, cs.Actions())
+}
+
+func TestInject_CacheMissOnStateChange(t *testing.T) {
+	//` — call `Inject` with `Status: True`, then with `Status: False`. Second call must hit the API (Get + UpdateStatus). Confirms real state changes are not suppressed by the cache.
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testPodName,
+			Namespace: testNS,
+		},
+	}
+
+	cs := fake.NewSimpleClientset(pod)
+	ci := NewConditionInjectorWithIdentity(cs, pod.Namespace, pod.Name)
+
+	cond := v1.PodCondition{
+		Type:               v1.PodConditionType(PodresourcesFetched),
+		Status:             v1.ConditionTrue,
+		LastTransitionTime: metav1.Time{Time: time.Now()},
+	}
+
+	ctx := context.Background()
+
+	// First call: cache is empty, should hit the API (get + update-status)
+	if err := ci.Inject(ctx, cond); err != nil {
+		t.Fatalf("first Inject failed: %v", err)
+	}
+
+	checkAPIServerUpdated(t, cs.Actions())
+
+	cs.ClearActions()
+
+	// Second call: condition flips to False, cache should pass through the API server
+	cond2 := v1.PodCondition{
+		Type:               v1.PodConditionType(PodresourcesFetched),
+		Status:             v1.ConditionFalse,
+		LastTransitionTime: metav1.Time{Time: time.Now().Add(10 * time.Second)},
+	}
+
+	if err := ci.Inject(ctx, cond2); err != nil {
+		t.Fatalf("second Inject failed: %v", err)
+	}
+
+	checkAPIServerUpdated(t, cs.Actions())
+
+	cs.ClearActions()
+
+	// Third call: at steady state again, cache should short-circuit
+	cond3 := v1.PodCondition{
+		Type:               v1.PodConditionType(PodresourcesFetched),
+		Status:             v1.ConditionFalse,
+		LastTransitionTime: metav1.Time{Time: time.Now().Add(20 * time.Second)},
+	}
+
+	if err := ci.Inject(ctx, cond3); err != nil {
+		t.Fatalf("third Inject failed: %v", err)
+	}
+
+	checkNoAPICalls(t, cs.Actions())
+}
+
+func TestInject_CacheNotPopulatedOnFailure(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testPodName,
+			Namespace: testNS,
+		},
+	}
+
+	cs := fake.NewSimpleClientset(pod)
+
+	called := false
+	cs.PrependReactor("update", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "status" {
+			return false, nil, nil
+		}
+		if !called {
+			called = true
+			return true, nil, fmt.Errorf("injected error")
+		}
+		return false, nil, nil
+	})
+
+	ci := NewConditionInjectorWithIdentity(cs, pod.Namespace, pod.Name)
+
+	cond := v1.PodCondition{
+		Type:               v1.PodConditionType(PodresourcesFetched),
+		Status:             v1.ConditionTrue,
+		LastTransitionTime: metav1.Time{Time: time.Now()},
+	}
+
+	ctx := context.Background()
+
+	// First call: cache is empty, should fail
+
+	if err := ci.Inject(ctx, cond); err == nil {
+		t.Fatalf("first Inject succeeded, it should fail")
+	}
+
+	checkAPIServerUpdated(t, cs.Actions())
+
+	cs.ClearActions()
+
+	// Second call: same condition with different timestamp, but cache expected empty, should hit the API (get + update-status)
+	cond2 := v1.PodCondition{
+		Type:               v1.PodConditionType(PodresourcesFetched),
+		Status:             v1.ConditionTrue,
+		LastTransitionTime: metav1.Time{Time: time.Now().Add(10 * time.Second)},
+	}
+
+	if err := ci.Inject(ctx, cond2); err != nil {
+		t.Fatalf("second Inject failed: %v", err)
+	}
+
+	checkAPIServerUpdated(t, cs.Actions())
+
+	cs.ClearActions()
+
+	// Third call: at steady state again, cache should short-circuit
+	cond3 := v1.PodCondition{
+		Type:               v1.PodConditionType(PodresourcesFetched),
+		Status:             v1.ConditionTrue,
+		LastTransitionTime: metav1.Time{Time: time.Now().Add(20 * time.Second)},
+	}
+
+	if err := ci.Inject(ctx, cond3); err != nil {
+		t.Fatalf("third Inject failed: %v", err)
+	}
+
+	checkNoAPICalls(t, cs.Actions())
+}
+
+func TestInject_ServerAlreadyHasStatus(t *testing.T) {
+	cond := v1.PodCondition{
+		Type:               v1.PodConditionType(PodresourcesFetched),
+		Status:             v1.ConditionTrue,
+		LastTransitionTime: metav1.Time{Time: time.Now()},
+	}
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testPodName,
+			Namespace: testNS,
+		},
+		Status: v1.PodStatus{
+			Conditions: []v1.PodCondition{cond},
+		},
+	}
+
+	cs := fake.NewSimpleClientset(pod)
+	ci := NewConditionInjectorWithIdentity(cs, pod.Namespace, pod.Name)
+
+	ctx := context.Background()
+
+	// First call: server already has the condition with matching status
+	if err := ci.Inject(ctx, cond); err != nil {
+		t.Fatalf("first Inject failed: %v", err)
+	}
+
+	checkAPIServerUpdated(t, cs.Actions())
+
+	cs.ClearActions()
+
+	// Second call: cache populated by get matching the desired state, so no more API calls are done
+	cond2 := v1.PodCondition{
+		Type:               v1.PodConditionType(PodresourcesFetched),
+		Status:             v1.ConditionTrue,
+		LastTransitionTime: metav1.Time{Time: time.Now().Add(10 * time.Second)},
+	}
+
+	if err := ci.Inject(ctx, cond2); err != nil {
+		t.Fatalf("second Inject failed: %v", err)
+	}
+
+	checkNoAPICalls(t, cs.Actions())
+}
+
+func checkAPIServerUpdated(t *testing.T, actions []k8stesting.Action) {
+	t.Helper()
+
+	if len(actions) != 2 {
+		t.Fatalf("expected 2 actions after first Inject, got %d: %v", len(actions), actions)
+	}
+	if verb := actions[0].GetVerb(); verb != "get" {
+		t.Errorf("first action: expected verb \"get\", got %q", verb)
+	}
+	if verb := actions[1].GetVerb(); verb != "update" {
+		t.Errorf("second action: expected verb \"update\", got %q", verb)
+	}
+	if sub := actions[1].GetSubresource(); sub != "status" {
+		t.Errorf("second action: expected subresource \"status\", got %q", sub)
+	}
+}
+
+func checkNoAPICalls(t *testing.T, actions []k8stesting.Action) {
+	if len(actions) != 0 {
+		t.Fatalf("expected still no actions after second Inject (cache hit), got %v", actions)
+	}
+}
+
+func makeBaseCondition() v1.PodCondition {
+	return v1.PodCondition{
+		Type:               v1.PodConditionType(PodresourcesFetched),
+		Status:             v1.ConditionTrue,
+		Reason:             "ScanOK",
+		Message:            "scan succeeded",
+		LastTransitionTime: metav1.Time{Time: time.Now()},
+	}
+}

--- a/pkg/resourcetopologyexporter/resourcetopologyexporter.go
+++ b/pkg/resourcetopologyexporter/resourcetopologyexporter.go
@@ -91,7 +91,7 @@ func Execute(hnd Handle, nrtupdaterArgs nrtupdater.Args, resourcemonitorArgs res
 		if err != nil {
 			return err
 		}
-		condIn.Run(condChan)
+		go condIn.Run(context.Background(), condChan)
 	}
 
 	eventSource, err := createEventSource(&rteArgs)


### PR DESCRIPTION
At steady state, we can observe 2 pod GETs per update cycle due to condition injection.
This is actually unnecessary: if the conditions we computed didn't change, we should not send updates.

The RTE is the sole owner of these specific conditions, so it is authoritative on them. OTOH, we now open the door to tampering, which the previous code prevented. But at scale, the API server load is halved, which is worth the tiny risk.

Should we need to be super safe, we can add an option to revert to the old behavior, but at this stage it seems unnecessary.