### PR TITLE
config: prefer config files over command line flags

### DIFF
--- a/manifests/resource-topology-exporter.yaml
+++ b/manifests/resource-topology-exporter.yaml
@@ -54,20 +54,25 @@ metadata:
 data:
   config.yaml: |
     global:
-      verbose: ${RTE_VERBOSE}
       debug: true
     nrtUpdater:
       patchMode: ${RTE_PATCH_MODE}
       patchResync: ${RTE_PATCH_RESYNC}
     resourceMonitor:
+      sysfsRoot: /host-sys
       exposeTiming: true
       refreshNodeResources: true
     topologyExporter:
+      sleepInterval: ${RTE_POLL_INTERVAL}
+      kubeletConfigFile: /host-var/lib/kubelet/config.yaml
+      podResourcesSocketPath: unix:///host-var/lib/kubelet/pod-resources/kubelet.sock
+      notifyFilePath: /host-run/rte/notify
       addNRTOwnerEnable: true
       podReadinessEnable: true
+      metricsMode: ${RTE_METRICS_MODE}
       metricsTLS:
         certsDir: /etc/secrets/rte
-        wantCliAuth: true
+        wantCliAuth: ${RTE_METRICS_CLI_AUTH}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -92,14 +97,8 @@ spec:
         command:
         - /bin/resource-topology-exporter
         args:
+          - -v=${RTE_VERBOSE}
           - --dump-config=.log
-          - --sleep-interval=${RTE_POLL_INTERVAL}
-          - --metrics-mode=${RTE_METRICS_MODE}
-          - --metrics-want-cli-auth=${RTE_METRICS_CLI_AUTH}
-          - --sysfs=/host-sys
-          - --kubelet-config-file=/host-var/lib/kubelet/config.yaml
-          - --podresources-socket=unix:///host-var/lib/kubelet/pod-resources/kubelet.sock
-          - --notify-file=/host-run/rte/notify
         env:
         - name: NODE_NAME
           valueFrom:

--- a/pkg/config/cfgdispatch.go
+++ b/pkg/config/cfgdispatch.go
@@ -69,11 +69,18 @@ func (cm configMap) Duration(key string, out *time.Duration) error {
 	if !ok {
 		return nil
 	}
-	j, ok := val.(float64)
-	if !ok {
-		return fmt.Errorf("key %q has non-float64 value representation %T", key, val)
+	switch v := val.(type) {
+	case float64:
+		*out = time.Duration(v)
+	case string:
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return fmt.Errorf("key %q: %w", key, err)
+		}
+		*out = d
+	default:
+		return fmt.Errorf("key %q has unsupported value type %T", key, val)
 	}
-	*out = time.Duration(j)
 	return nil
 }
 
@@ -118,6 +125,7 @@ func dispatchConfObj(obj map[string]interface{}, pArgs *ProgArgs) error {
 		{key: "resourceMonitor.exposeTiming", out: &pArgs.Resourcemonitor.ExposeTiming},
 		{key: "resourceMonitor.podSetFingerprintStatusFile", out: &pArgs.Resourcemonitor.PodSetFingerprintStatusFile},
 		{key: "resourceMonitor.excludeTerminalPods", out: &pArgs.Resourcemonitor.ExcludeTerminalPods},
+		{key: "topologyExporter.kubeletConfigFile", out: &pArgs.RTE.KubeletConfigFile},
 		{key: "topologyExporter.podResourcesSocketPath", out: &pArgs.RTE.PodResourcesSocketPath},
 		{key: "topologyExporter.sleepInterval", out: &pArgs.RTE.SleepInterval},
 		{key: "topologyExporter.podReadinessEnable", out: &pArgs.RTE.PodReadinessEnable},

--- a/pkg/config/cfgdispatch.go
+++ b/pkg/config/cfgdispatch.go
@@ -134,7 +134,7 @@ func dispatchConfObj(obj map[string]interface{}, pArgs *ProgArgs) error {
 		{key: "topologyExporter.addNRTOwnerEnable", out: &pArgs.RTE.AddNRTOwnerEnable},
 		{key: "topologyExporter.metricsMode", out: &pArgs.RTE.MetricsMode},
 		{key: "topologyExporter.metricsPort", out: &pArgs.RTE.MetricsPort},
-		{key: "topologyExporter.MetricsAddress", out: &pArgs.RTE.MetricsAddress},
+		{key: "topologyExporter.metricsAddress", out: &pArgs.RTE.MetricsAddress},
 		{key: "topologyExporter.metricsTLS.certsDir", out: &pArgs.RTE.MetricsTLSCfg.CertsDir},
 		{key: "topologyExporter.metricsTLS.certFile", out: &pArgs.RTE.MetricsTLSCfg.CertFile},
 		{key: "topologyExporter.metricsTLS.keyFile", out: &pArgs.RTE.MetricsTLSCfg.KeyFile},

--- a/pkg/config/cfgfile_test.go
+++ b/pkg/config/cfgfile_test.go
@@ -68,6 +68,37 @@ func TestReadResourceExclude(t *testing.T) {
 	}
 }
 
+func TestMetricsAddressFromConfig(t *testing.T) {
+	testDir, closer := setupTest(t)
+	t.Cleanup(closer)
+
+	confRoot := filepath.Join(testDir, "test-metrics-address")
+	daemonDir := filepath.Join(confRoot, "daemon")
+	if err := os.MkdirAll(daemonDir, 0755); err != nil {
+		t.Fatalf("unexpected error creating daemon dir: %v", err)
+	}
+
+	expected := `topologyExporter:
+  metricsAddress: 192.168.1.100
+`
+	expectedAddress := "192.168.1.100"
+
+	if err := os.WriteFile(filepath.Join(daemonDir, "config.yaml"), []byte(expected), 0644); err != nil {
+		t.Fatalf("unexpected error writing config: %v", err)
+	}
+
+	var pArgs ProgArgs
+	SetDefaults(&pArgs)
+	extraPath := FixExtraConfigPath(confRoot)
+	if err := FromFiles(&pArgs, confRoot, extraPath); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if pArgs.RTE.MetricsAddress != expectedAddress {
+		t.Errorf("MetricsAddress: got %q expected %q", pArgs.RTE.MetricsAddress, expectedAddress)
+	}
+}
+
 func TestFromFiles(t *testing.T) {
 	testDir, closer := setupTest(t)
 	t.Cleanup(closer)

--- a/test/e2e/rte/conditions.go
+++ b/test/e2e/rte/conditions.go
@@ -77,15 +77,15 @@ var _ = ginkgo.Describe("[RTE][Monitoring] conditions", func() {
 
 	ginkgo.Context("with NRT objects created", func() {
 		ginkgo.It("[release] should have custom RTE conditions under the pod status", func() {
-			gomega.Eventually(func() bool {
-				return waitForPodCondition(e2etestenv.RTELabelName, podreadiness.PodresourcesFetched, corev1.ConditionTrue)
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(waitForPodCondition(e2etestenv.RTELabelName, podreadiness.PodresourcesFetched, corev1.ConditionTrue)).To(gomega.BeTrue(), "pod contains wrong condition value")
 				// wait for twice the poll interval, so the conditions will have enough time to get updated
-			}).WithTimeout(2*timeout).WithPolling(1*time.Second).Should(gomega.BeTrue(), "pod contains wrong condition value")
+			}).WithTimeout(2 * timeout).WithPolling(1 * time.Second).Should(gomega.Succeed())
 
-			gomega.Eventually(func() bool {
-				return waitForPodCondition(e2etestenv.RTELabelName, podreadiness.NodeTopologyUpdated, corev1.ConditionTrue)
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(waitForPodCondition(e2etestenv.RTELabelName, podreadiness.NodeTopologyUpdated, corev1.ConditionTrue)).To(gomega.BeTrue(), "pod contains wrong condition value")
 				// wait for twice the poll interval, so the conditions will have enough time to get updated
-			}).WithTimeout(2*timeout).WithPolling(1*time.Second).Should(gomega.BeTrue(), "pod contains wrong condition value")
+			}).WithTimeout(2 * timeout).WithPolling(1 * time.Second).Should(gomega.Succeed())
 		})
 
 		// EventChain means that the test can be flaky in some specific cases, for example deleted CRD can be re-installed
@@ -96,19 +96,19 @@ var _ = ginkgo.Describe("[RTE][Monitoring] conditions", func() {
 			err := f.ApiExt.ApiextensionsV1().CustomResourceDefinitions().Delete(context.TODO(), crdName, metav1.DeleteOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			gomega.Eventually(func() bool {
-				return waitForPodCondition(e2etestenv.RTELabelName, podreadiness.NodeTopologyUpdated, corev1.ConditionFalse)
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(waitForPodCondition(e2etestenv.RTELabelName, podreadiness.NodeTopologyUpdated, corev1.ConditionFalse)).To(gomega.BeTrue(), "pod contains wrong condition value")
 				// wait for twice the poll interval, so the conditions will have enough time to get updated
-			}).WithTimeout(2*timeout).WithPolling(1*time.Second).Should(gomega.BeTrue(), "pod contains wrong condition value")
+			}).WithTimeout(2 * timeout).WithPolling(1 * time.Second).Should(gomega.Succeed())
 
 			ginkgo.By("recreating the crd")
 			crd.ResourceVersion = ""
 			_, err = f.ApiExt.ApiextensionsV1().CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			gomega.Eventually(func() bool {
-				return waitForPodCondition(e2etestenv.RTELabelName, podreadiness.NodeTopologyUpdated, corev1.ConditionFalse)
-			}).WithTimeout(2*timeout).WithPolling(1*time.Second).Should(gomega.BeTrue(), "pod contains wrong condition value")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(waitForPodCondition(e2etestenv.RTELabelName, podreadiness.NodeTopologyUpdated, corev1.ConditionFalse)).To(gomega.BeTrue(), "pod contains wrong condition value")
+			}).WithTimeout(2 * timeout).WithPolling(1 * time.Second).Should(gomega.Succeed())
 		})
 	})
 })

--- a/test/e2e/rte/metrics.go
+++ b/test/e2e/rte/metrics.go
@@ -23,7 +23,6 @@ package rte
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -127,13 +126,15 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 			key := client.ObjectKeyFromObject(rtePod)
 			klog.Infof("executing cmd: %s on pod %q", cmd, key.String())
 			var stdout, stderr []byte
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func(g gomega.Gomega) {
 				var err error
 				stdout, stderr, err = remoteexec.CommandOnPod(f.Ctx, f.K8SCli, rtePod, rteContainerName, cmd...)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed exec command on pod. pod=%q; cmd=%q; err=%v; stderr=%q", key.String(), cmd, err, stderr)
-				return strings.Contains(string(stdout), "operation_delay") &&
-					strings.Contains(string(stdout), "wakeup_delay")
-			}).WithPolling(10*time.Second).WithTimeout(3*time.Minute).Should(gomega.BeTrue(), "failed to get metrics from pod\nstdout=%q\nstderr=%q\n", stdout, stderr)
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "failed exec command on pod. pod=%q; cmd=%q; err=%v; stderr=%q", key.String(), cmd, err, stderr)
+				g.Expect(string(stdout)).To(gomega.And(
+					gomega.ContainSubstring("operation_delay"),
+					gomega.ContainSubstring("wakeup_delay"),
+				), "failed to get metrics from pod\nstdout=%q\nstderr=%q\n", stdout, stderr)
+			}).WithPolling(10 * time.Second).WithTimeout(3 * time.Minute).Should(gomega.Succeed())
 		})
 
 		ginkgo.It("[EventChain] should have some metrics exported over plain http", func() {
@@ -146,13 +147,15 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 			key := client.ObjectKeyFromObject(rtePod)
 			klog.Infof("executing cmd: %s on pod %q", cmd, key.String())
 			var stdout, stderr []byte
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func(g gomega.Gomega) {
 				var err error
 				stdout, stderr, err = remoteexec.CommandOnPod(f.Ctx, f.K8SCli, rtePod, rteContainerName, cmd...)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed exec command on pod. pod=%q; cmd=%q; err=%v; stderr=%q", key.String(), cmd, err, stderr)
-				return strings.Contains(string(stdout), "operation_delay") &&
-					strings.Contains(string(stdout), "wakeup_delay")
-			}).WithPolling(10*time.Second).WithTimeout(3*time.Minute).Should(gomega.BeTrue(), "failed to get metrics from pod\nstdout=%q\nstderr=%q\n", stdout, stderr)
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "failed exec command on pod. pod=%q; cmd=%q; err=%v; stderr=%q", key.String(), cmd, err, stderr)
+				g.Expect(string(stdout)).To(gomega.And(
+					gomega.ContainSubstring("operation_delay"),
+					gomega.ContainSubstring("wakeup_delay"),
+				), "failed to get metrics from pod\nstdout=%q\nstderr=%q\n", stdout, stderr)
+			}).WithPolling(10 * time.Second).WithTimeout(3 * time.Minute).Should(gomega.Succeed())
 		})
 		ginkgo.It("[release] it should report noderesourcetopology writes", func() {
 			if metricsMode != "http" {
@@ -180,13 +183,13 @@ var _ = ginkgo.Describe("[RTE][Monitoring] metrics", func() {
 			key := client.ObjectKeyFromObject(rtePod)
 			klog.Infof("executing cmd: %s on pod %q", cmd, key.String())
 			var stdout, stderr []byte
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func(g gomega.Gomega) {
 				var err error
 				stdout, stderr, err = remoteexec.CommandOnPod(f.Ctx, f.K8SCli, rtePod, rteContainerName, cmd...)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed exec command on pod. pod=%q; cmd=%q; err=%v; stderr=%q", key.String(), cmd, err, stderr)
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "failed exec command on pod. pod=%q; cmd=%q; err=%v; stderr=%q", key.String(), cmd, err, stderr)
 
-				return strings.Contains(string(stdout), "noderesourcetopology_writes_total")
-			}).WithPolling(10*time.Second).WithTimeout(2*time.Minute).Should(gomega.BeTrue(), "failed to get metrics from pod\nstdout=%q\nstderr=%q\n", stdout, stderr)
+				g.Expect(string(stdout)).To(gomega.ContainSubstring("noderesourcetopology_writes_total"), "failed to get metrics from pod\nstdout=%q\nstderr=%q\n", stdout, stderr)
+			}).WithPolling(10 * time.Second).WithTimeout(2 * time.Minute).Should(gomega.Succeed())
 		})
 	})
 })

--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -304,20 +304,21 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 })
 
 func getUpdatedNRT(topologyClient *topologyclientset.Clientset, nodeName string, prevNrt v1alpha2.NodeResourceTopology, timeout time.Duration) *v1alpha2.NodeResourceTopology {
+	ginkgo.GinkgoHelper()
+	effectiveTimeout := timeout + updateIntervalExtraSafety
+	klog.Infof("waiting for NRT %q update: timeout %v (base %v + safety %v) prev resourceVersion=%v", nodeName, effectiveTimeout, timeout, updateIntervalExtraSafety, prevNrt.ObjectMeta.ResourceVersion)
 	var err error
 	var currNrt *v1alpha2.NodeResourceTopology
-	gomega.EventuallyWithOffset(1, func() bool {
+	gomega.Eventually(func() error {
 		currNrt, err = topologyClient.TopologyV1alpha2().NodeResourceTopologies().Get(context.TODO(), nodeName, metav1.GetOptions{})
 		if err != nil {
-			klog.Infof("failed to get the node topology resource: %v", err)
-			return false
+			return fmt.Errorf("failed to get the node topology resource: %w", err)
 		}
 		if currNrt.ObjectMeta.ResourceVersion == prevNrt.ObjectMeta.ResourceVersion {
-			klog.Infof("resource %s not yet updated - resource version not bumped", nodeName)
-			return false
+			return fmt.Errorf("resource %s not yet updated - resource version not bumped", nodeName)
 		}
-		return true
-	}).WithTimeout(timeout+updateIntervalExtraSafety).WithPolling(1*time.Second).Should(gomega.BeTrue(), "didn't get updated node topology info")
+		return nil
+	}).WithTimeout(effectiveTimeout).WithPolling(1*time.Second).Should(gomega.Succeed(), "didn't get updated node topology info")
 	return currNrt
 }
 
@@ -404,7 +405,8 @@ func estimateUpdateInterval(nrt v1alpha2.NodeResourceTopology) (time.Duration, s
 		return fallbackInterval, "estimated", nil
 	}
 	updateInterval, err := time.ParseDuration(updateIntervalAnn)
-	if err != nil {
+	if err != nil || updateInterval <= 0 {
+		klog.Warningf("annotation %q has unusable value %q (parsed=%v err=%v), falling back to %v", k8sannotations.UpdateInterval, updateIntervalAnn, updateInterval, err, fallbackInterval)
 		return fallbackInterval, "estimated", err
 	}
 	return updateInterval, "computed", nil

--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -22,6 +22,7 @@ package rte
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -97,63 +98,60 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 		ginkgo.It("[NotificationFile] it should react to pod changes using the smart poller with notification file", func() {
 			initialNodeTopo := e2enodetopology.GetNodeTopology(f.TopoCli, topologyUpdaterNode.Name)
 
-			stopChan := make(chan struct{})
-			doneChan := make(chan struct{})
-			started := false
-
-			go func() {
-				defer ginkgo.GinkgoRecover()
-
-				<-stopChan
-				rtePod, err := e2epods.GetPodOnNode(f.K8SCli, topologyUpdaterNode.Name, e2etestenv.GetNamespaceName(), e2etestenv.RTELabelName)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-				rteContainerName, err := e2ertepod.FindRTEContainerName(rtePod)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-				rteNotifyFilePath, err := e2ertepod.FindNotificationFilePath(f.Ctx, f.K8SCli, rtePod)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-				cmd := []string{"/bin/touch", rteNotifyFilePath}
-				_, _, err = remoteexec.CommandOnPod(f.Ctx, f.K8SCli, rtePod, rteContainerName, cmd...)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed exec command %v on pod %q", cmd, client.ObjectKeyFromObject(rtePod).String())
-				klog.Infof("notification triggered, exiting")
-				doneChan <- struct{}{}
-			}()
-
-			ginkgo.By("getting the updated topology")
-			var err error
-			var finalNodeTopo *v1alpha2.NodeResourceTopology
-			gomega.Eventually(func() bool {
-				if !started {
-					stopChan <- struct{}{}
-					started = true
+			ginkgo.By("waiting for a periodic update to find the optimal update window")
+			var baselineNodeTopo *v1alpha2.NodeResourceTopology
+			gomega.Eventually(func() error {
+				var err error
+				baselineNodeTopo, err = f.TopoCli.TopologyV1alpha2().NodeResourceTopologies().Get(context.TODO(), topologyUpdaterNode.Name, metav1.GetOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to get the node topology resource: %w", err)
 				}
+				if baselineNodeTopo.ObjectMeta.ResourceVersion == initialNodeTopo.ObjectMeta.ResourceVersion {
+					return fmt.Errorf("resource %s not yet updated - resource version not bumped", topologyUpdaterNode.Name)
+				}
+				klog.Infof("resource %s baseline update (resource version %v -> %v)", topologyUpdaterNode.Name, initialNodeTopo.ObjectMeta.ResourceVersion, baselineNodeTopo.ObjectMeta.ResourceVersion)
+				return nil
+			}).WithTimeout(31*time.Second).WithPolling(1*time.Second).Should(gomega.Succeed(), "didn't get baseline periodic update")
 
+			ginkgo.By("triggering notification using the file")
+			rtePod, err := e2epods.GetPodOnNode(f.K8SCli, topologyUpdaterNode.Name, e2etestenv.GetNamespaceName(), e2etestenv.RTELabelName)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			rteContainerName, err := e2ertepod.FindRTEContainerName(rtePod)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			rteNotifyFilePath, err := e2ertepod.FindNotificationFilePath(f.Ctx, f.K8SCli, rtePod)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			cmd := []string{"/bin/touch", rteNotifyFilePath}
+			_, _, err = remoteexec.CommandOnPod(f.Ctx, f.K8SCli, rtePod, rteContainerName, cmd...)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed exec command %v on pod %q", cmd, client.ObjectKeyFromObject(rtePod).String())
+			klog.Infof("notification triggered")
+
+			ginkgo.By("waiting for reactive topology update")
+			var finalNodeTopo *v1alpha2.NodeResourceTopology
+			gomega.Eventually(func() error {
 				finalNodeTopo, err = f.TopoCli.TopologyV1alpha2().NodeResourceTopologies().Get(context.TODO(), topologyUpdaterNode.Name, metav1.GetOptions{})
 				if err != nil {
-					klog.Infof("failed to get the node topology resource: %v", err)
-					return false
+					return fmt.Errorf("failed to get the node topology resource: %w", err)
 				}
-				if finalNodeTopo.ObjectMeta.ResourceVersion == initialNodeTopo.ObjectMeta.ResourceVersion {
-					klog.Infof("resource %s not yet updated - resource version not bumped", topologyUpdaterNode.Name)
-					return false
+				if finalNodeTopo.ObjectMeta.ResourceVersion == baselineNodeTopo.ObjectMeta.ResourceVersion {
+					return fmt.Errorf("resource %s not yet updated - resource version not bumped", topologyUpdaterNode.Name)
 				}
 
-				klog.Infof("resource %s updated! - resource version bumped (old %v new %v)", topologyUpdaterNode.Name, initialNodeTopo.ObjectMeta.ResourceVersion, finalNodeTopo.ObjectMeta.ResourceVersion)
+				klog.Infof("resource %s updated! - resource version bumped (old %v new %v)", topologyUpdaterNode.Name, baselineNodeTopo.ObjectMeta.ResourceVersion, finalNodeTopo.ObjectMeta.ResourceVersion)
 
 				reason, ok := finalNodeTopo.Annotations[k8sannotations.RTEUpdate]
 				if !ok {
-					klog.Infof("resource %s missing annotation!", topologyUpdaterNode.Name)
-					return false
+					return fmt.Errorf("resource %s missing annotation!", topologyUpdaterNode.Name)
 				}
-				klog.Infof("resource %s reason %v expected %v", topologyUpdaterNode.Name, reason, nrtupdater.RTEUpdateReactive)
-				return reason == nrtupdater.RTEUpdateReactive
-			}).WithTimeout(31*time.Second).WithPolling(1*time.Second).Should(gomega.BeTrue(), "didn't get updated node topology info")
+				if reason != nrtupdater.RTEUpdateReactive {
+					return fmt.Errorf("resource %s reason %v expected %v", topologyUpdaterNode.Name, reason, nrtupdater.RTEUpdateReactive)
+				}
+				return nil
+			}).WithTimeout(31*time.Second).WithPolling(1*time.Second).Should(gomega.Succeed(), "didn't get updated node topology info")
+
 			ginkgo.By("checking the topology was updated for the right reason")
-
-			<-doneChan
-
 			gomega.Expect(finalNodeTopo.Annotations).ToNot(gomega.BeNil(), "missing annotations entirely")
 			reason := finalNodeTopo.Annotations[k8sannotations.RTEUpdate]
 			gomega.Expect(reason).To(gomega.Equal(nrtupdater.RTEUpdateReactive), "update reason error: expected %q got %q", nrtupdater.RTEUpdateReactive, reason)

--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -111,7 +111,7 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 				rteContainerName, err := e2ertepod.FindRTEContainerName(rtePod)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-				rteNotifyFilePath, err := e2ertepod.FindNotificationFilePath(rtePod)
+				rteNotifyFilePath, err := e2ertepod.FindNotificationFilePath(f.Ctx, f.K8SCli, rtePod)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 				cmd := []string{"/bin/touch", rteNotifyFilePath}

--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -22,8 +22,6 @@ package rte
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -100,17 +98,12 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 
 			ginkgo.By("waiting for a periodic update to find the optimal update window")
 			var baselineNodeTopo *v1alpha2.NodeResourceTopology
-			gomega.Eventually(func() error {
+			gomega.Eventually(func(g gomega.Gomega) {
 				var err error
 				baselineNodeTopo, err = f.TopoCli.TopologyV1alpha2().NodeResourceTopologies().Get(context.TODO(), topologyUpdaterNode.Name, metav1.GetOptions{})
-				if err != nil {
-					return fmt.Errorf("failed to get the node topology resource: %w", err)
-				}
-				if baselineNodeTopo.ObjectMeta.ResourceVersion == initialNodeTopo.ObjectMeta.ResourceVersion {
-					return fmt.Errorf("resource %s not yet updated - resource version not bumped", topologyUpdaterNode.Name)
-				}
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to get the node topology resource")
+				g.Expect(baselineNodeTopo.ObjectMeta.ResourceVersion).ToNot(gomega.Equal(initialNodeTopo.ObjectMeta.ResourceVersion), "resource %s not yet updated - resource version not bumped", topologyUpdaterNode.Name)
 				klog.Infof("resource %s baseline update (resource version %v -> %v)", topologyUpdaterNode.Name, initialNodeTopo.ObjectMeta.ResourceVersion, baselineNodeTopo.ObjectMeta.ResourceVersion)
-				return nil
 			}).WithTimeout(31*time.Second).WithPolling(1*time.Second).Should(gomega.Succeed(), "didn't get baseline periodic update")
 
 			ginkgo.By("triggering notification using the file")
@@ -130,25 +123,16 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 
 			ginkgo.By("waiting for reactive topology update")
 			var finalNodeTopo *v1alpha2.NodeResourceTopology
-			gomega.Eventually(func() error {
+			gomega.Eventually(func(g gomega.Gomega) {
 				finalNodeTopo, err = f.TopoCli.TopologyV1alpha2().NodeResourceTopologies().Get(context.TODO(), topologyUpdaterNode.Name, metav1.GetOptions{})
-				if err != nil {
-					return fmt.Errorf("failed to get the node topology resource: %w", err)
-				}
-				if finalNodeTopo.ObjectMeta.ResourceVersion == baselineNodeTopo.ObjectMeta.ResourceVersion {
-					return fmt.Errorf("resource %s not yet updated - resource version not bumped", topologyUpdaterNode.Name)
-				}
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to get the node topology resource")
+				g.Expect(finalNodeTopo.ObjectMeta.ResourceVersion).ToNot(gomega.Equal(baselineNodeTopo.ObjectMeta.ResourceVersion), "resource %s not yet updated - resource version not bumped", topologyUpdaterNode.Name)
 
 				klog.Infof("resource %s updated! - resource version bumped (old %v new %v)", topologyUpdaterNode.Name, baselineNodeTopo.ObjectMeta.ResourceVersion, finalNodeTopo.ObjectMeta.ResourceVersion)
 
 				reason, ok := finalNodeTopo.Annotations[k8sannotations.RTEUpdate]
-				if !ok {
-					return fmt.Errorf("resource %s missing annotation!", topologyUpdaterNode.Name)
-				}
-				if reason != nrtupdater.RTEUpdateReactive {
-					return fmt.Errorf("resource %s reason %v expected %v", topologyUpdaterNode.Name, reason, nrtupdater.RTEUpdateReactive)
-				}
-				return nil
+				g.Expect(ok).To(gomega.BeTrue(), "resource %s missing annotation!", topologyUpdaterNode.Name)
+				g.Expect(reason).To(gomega.Equal(nrtupdater.RTEUpdateReactive), "resource %s reason %v expected %v", topologyUpdaterNode.Name, reason, nrtupdater.RTEUpdateReactive)
 			}).WithTimeout(31*time.Second).WithPolling(1*time.Second).Should(gomega.Succeed(), "didn't get updated node topology info")
 
 			ginkgo.By("checking the topology was updated for the right reason")
@@ -272,18 +256,19 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 	})
 	ginkgo.Context("with refresh-node-resources enabled", func() {
 		ginkgo.It("[NodeRefresh] should be able to detect devices", func() {
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func(g gomega.Gomega) {
 				nrt := e2enodetopology.GetNodeTopology(f.TopoCli, topologyUpdaterNode.Name)
 				devName := e2etestenv.GetDeviceName()
+				found := false
 				for _, zone := range nrt.Zones {
 					for _, res := range zone.Resources {
 						if res.Name == devName {
-							return true
+							found = true
 						}
 					}
 				}
-				return false
-			}).WithTimeout(30*time.Second).WithPolling(10*time.Second).Should(gomega.BeTrue(), "device: %q was not found in NRT: %q", e2etestenv.GetDeviceName(), topologyUpdaterNode.Name)
+				g.Expect(found).To(gomega.BeTrue(), "device: %q was not found in NRT: %q", devName, topologyUpdaterNode.Name)
+			}).WithTimeout(30 * time.Second).WithPolling(10 * time.Second).Should(gomega.Succeed())
 		})
 
 		ginkgo.It("[NodeRefresh] should log the refresh message", func() {
@@ -293,12 +278,15 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 			rteContainerName, err := e2ertepod.FindRTEContainerName(rtePod)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func(g gomega.Gomega) {
 				logs, err := e2epods.GetLogsForPod(f.K8SCli, rtePod.Namespace, rtePod.Name, rteContainerName)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				g.Expect(err).ToNot(gomega.HaveOccurred())
 
-				return strings.Contains(logs, "tracking node resources") || strings.Contains(logs, "update node resources")
-			}).WithTimeout(42*time.Second).WithPolling(5*time.Second).Should(gomega.BeTrue(), "container: %q in pod: %q doesn't contains the refresh log message", rteContainerName, rtePod.Name)
+				g.Expect(logs).To(gomega.Or(
+					gomega.ContainSubstring("tracking node resources"),
+					gomega.ContainSubstring("update node resources"),
+				), "container: %q in pod: %q doesn't contain the refresh log message", rteContainerName, rtePod.Name)
+			}).WithTimeout(42 * time.Second).WithPolling(5 * time.Second).Should(gomega.Succeed())
 		})
 	})
 })
@@ -309,15 +297,10 @@ func getUpdatedNRT(topologyClient *topologyclientset.Clientset, nodeName string,
 	klog.Infof("waiting for NRT %q update: timeout %v (base %v + safety %v) prev resourceVersion=%v", nodeName, effectiveTimeout, timeout, updateIntervalExtraSafety, prevNrt.ObjectMeta.ResourceVersion)
 	var err error
 	var currNrt *v1alpha2.NodeResourceTopology
-	gomega.Eventually(func() error {
+	gomega.Eventually(func(g gomega.Gomega) {
 		currNrt, err = topologyClient.TopologyV1alpha2().NodeResourceTopologies().Get(context.TODO(), nodeName, metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to get the node topology resource: %w", err)
-		}
-		if currNrt.ObjectMeta.ResourceVersion == prevNrt.ObjectMeta.ResourceVersion {
-			return fmt.Errorf("resource %s not yet updated - resource version not bumped", nodeName)
-		}
-		return nil
+		g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to get the node topology resource")
+		g.Expect(currNrt.ObjectMeta.ResourceVersion).ToNot(gomega.Equal(prevNrt.ObjectMeta.ResourceVersion), "resource %s not yet updated - resource version not bumped", nodeName)
 	}).WithTimeout(effectiveTimeout).WithPolling(1*time.Second).Should(gomega.Succeed(), "didn't get updated node topology info")
 	return currNrt
 }

--- a/test/e2e/rte/rte.go
+++ b/test/e2e/rte/rte.go
@@ -96,6 +96,11 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 		ginkgo.It("[NotificationFile] it should react to pod changes using the smart poller with notification file", func() {
 			initialNodeTopo := e2enodetopology.GetNodeTopology(f.TopoCli, topologyUpdaterNode.Name)
 
+			updateInterval, method, err := estimateUpdateInterval(*initialNodeTopo)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			baselineTimeout := 5*updateInterval + updateIntervalExtraSafety
+			klog.Infof("%s update interval: %s (timeout %s)", method, updateInterval, baselineTimeout)
+
 			ginkgo.By("waiting for a periodic update to find the optimal update window")
 			var baselineNodeTopo *v1alpha2.NodeResourceTopology
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -104,7 +109,7 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 				g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to get the node topology resource")
 				g.Expect(baselineNodeTopo.ObjectMeta.ResourceVersion).ToNot(gomega.Equal(initialNodeTopo.ObjectMeta.ResourceVersion), "resource %s not yet updated - resource version not bumped", topologyUpdaterNode.Name)
 				klog.Infof("resource %s baseline update (resource version %v -> %v)", topologyUpdaterNode.Name, initialNodeTopo.ObjectMeta.ResourceVersion, baselineNodeTopo.ObjectMeta.ResourceVersion)
-			}).WithTimeout(31*time.Second).WithPolling(1*time.Second).Should(gomega.Succeed(), "didn't get baseline periodic update")
+			}).WithTimeout(baselineTimeout).WithPolling(1*time.Second).Should(gomega.Succeed(), "didn't get baseline periodic update")
 
 			ginkgo.By("triggering notification using the file")
 			rtePod, err := e2epods.GetPodOnNode(f.K8SCli, topologyUpdaterNode.Name, e2etestenv.GetNamespaceName(), e2etestenv.RTELabelName)
@@ -133,7 +138,7 @@ var _ = ginkgo.Describe("[RTE][InfraConsuming] Resource topology exporter", func
 				reason, ok := finalNodeTopo.Annotations[k8sannotations.RTEUpdate]
 				g.Expect(ok).To(gomega.BeTrue(), "resource %s missing annotation!", topologyUpdaterNode.Name)
 				g.Expect(reason).To(gomega.Equal(nrtupdater.RTEUpdateReactive), "resource %s reason %v expected %v", topologyUpdaterNode.Name, reason, nrtupdater.RTEUpdateReactive)
-			}).WithTimeout(31*time.Second).WithPolling(1*time.Second).Should(gomega.Succeed(), "didn't get updated node topology info")
+			}).WithTimeout(baselineTimeout).WithPolling(1*time.Second).Should(gomega.Succeed(), "didn't get updated node topology info")
 
 			ginkgo.By("checking the topology was updated for the right reason")
 			gomega.Expect(finalNodeTopo.Annotations).ToNot(gomega.BeNil(), "missing annotations entirely")

--- a/test/e2e/topology_updater/topology_updater.go
+++ b/test/e2e/topology_updater/topology_updater.go
@@ -24,7 +24,6 @@ package topology_updater
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -111,24 +110,12 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 				Kind:       "Node",
 				UID:        topologyUpdaterNode.UID,
 			}
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func(g gomega.Gomega) {
 				finalNodeTopo, err := f.TopoCli.TopologyV1alpha2().NodeResourceTopologies().Get(context.TODO(), topologyUpdaterNode.Name, metav1.GetOptions{})
-				if err != nil {
-					klog.Infof("failed to get the node topology resource: %v", err)
-					return false
-				}
-
-				if len(finalNodeTopo.OwnerReferences) != 1 {
-					klog.Infof("Too many OwnerReferences: expected=1; got=%d", len(finalNodeTopo.OwnerReferences))
-					klog.Infof("%+#v", finalNodeTopo.OwnerReferences)
-					return false
-				}
-				if !reflect.DeepEqual(finalNodeTopo.OwnerReferences[0], expectedOwnerReference) {
-					klog.Infof("Unexpected OwnerReference: expected=%+#v; got=%+#v", expectedOwnerReference, finalNodeTopo.OwnerReferences[0])
-					return false
-				}
-				return true
-			}).WithTimeout(5*timeout).WithPolling(5*time.Second).Should(gomega.BeTrue(), "didn't get updated node topology info")
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to get the node topology resource")
+				g.Expect(finalNodeTopo.OwnerReferences).To(gomega.HaveLen(1), "unexpected number of OwnerReferences")
+				g.Expect(finalNodeTopo.OwnerReferences[0]).To(gomega.Equal(expectedOwnerReference), "unexpected OwnerReference")
+			}).WithTimeout(5*timeout).WithPolling(5*time.Second).Should(gomega.Succeed(), "didn't get updated node topology info")
 		})
 		ginkgo.It("it should not account for any cpus if a container doesn't request exclusive cpus (best effort QOS)", func() {
 			devName := e2etestenv.GetDeviceName()
@@ -231,14 +218,11 @@ var _ = ginkgo.Describe("[TopologyUpdater][InfraConsuming] Node topology updater
 
 			ginkgo.By("getting the updated topology")
 			var finalNodeTopo *v1alpha2.NodeResourceTopology
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func(g gomega.Gomega) {
 				finalNodeTopo, err = f.TopoCli.TopologyV1alpha2().NodeResourceTopologies().Get(context.TODO(), topologyUpdaterNode.Name, metav1.GetOptions{})
-				if err != nil {
-					klog.Infof("failed to get the node topology resource: %v", err)
-					return false
-				}
-				return finalNodeTopo.ObjectMeta.Generation != initialNodeTopo.ObjectMeta.Generation
-			}).WithTimeout(5*timeout).WithPolling(5*time.Second).Should(gomega.BeTrue(), "didn't get updated node topology info")
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to get the node topology resource")
+				g.Expect(finalNodeTopo.ObjectMeta.Generation).ToNot(gomega.Equal(initialNodeTopo.ObjectMeta.Generation), "resource %s not yet updated - generation not bumped", topologyUpdaterNode.Name)
+			}).WithTimeout(5*timeout).WithPolling(5*time.Second).Should(gomega.Succeed(), "didn't get updated node topology info")
 			klog.Infof("final topology information: %#v", initialNodeTopo)
 
 			ginkgo.By("checking the changes in the updated topology")

--- a/test/e2e/utils/nodetopology/nodetopology.go
+++ b/test/e2e/utils/nodetopology/nodetopology.go
@@ -47,21 +47,24 @@ func GetNodeTopology(topologyClient *topologyclientset.Clientset, nodeName strin
 }
 
 func GetNodeTopologyWithResource(topologyClient *topologyclientset.Clientset, nodeName, resName string) *v1alpha2.NodeResourceTopology {
+	ginkgo.GinkgoHelper()
 	ginkgo.By(fmt.Sprintf("getting NRT for node=%q resource=%q", nodeName, resName))
 
 	var nodeTopology *v1alpha2.NodeResourceTopology
 	var err error
-	gomega.EventuallyWithOffset(1, func() bool {
+	gomega.Eventually(func() error {
 		nodeTopology, err = topologyClient.TopologyV1alpha2().NodeResourceTopologies().Get(context.TODO(), nodeName, metav1.GetOptions{})
 		if err != nil {
-			klog.Infof("failed to get the node topology resource: %v", err)
-			return false
+			return fmt.Errorf("failed to get the node topology resource: %w", err)
 		}
 		if resName == "" {
-			return true
+			return nil // legit case
 		}
-		return containsResource(nodeTopology, resName)
-	}).WithTimeout(time.Minute).WithPolling(5 * time.Second).Should(gomega.BeTrue())
+		if !containsResource(nodeTopology, resName) {
+			return fmt.Errorf("the node topology data doesn't include resource %q", resName)
+		}
+		return nil
+	}).WithTimeout(time.Minute).WithPolling(5 * time.Second).Should(gomega.Succeed())
 
 	return nodeTopology
 }

--- a/test/e2e/utils/nodetopology/nodetopology.go
+++ b/test/e2e/utils/nodetopology/nodetopology.go
@@ -52,18 +52,12 @@ func GetNodeTopologyWithResource(topologyClient *topologyclientset.Clientset, no
 
 	var nodeTopology *v1alpha2.NodeResourceTopology
 	var err error
-	gomega.Eventually(func() error {
+	gomega.Eventually(func(g gomega.Gomega) {
 		nodeTopology, err = topologyClient.TopologyV1alpha2().NodeResourceTopologies().Get(context.TODO(), nodeName, metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to get the node topology resource: %w", err)
+		g.Expect(err).ToNot(gomega.HaveOccurred(), "failed to get the node topology resource")
+		if resName != "" {
+			g.Expect(containsResource(nodeTopology, resName)).To(gomega.BeTrue(), "the node topology data doesn't include resource %q", resName)
 		}
-		if resName == "" {
-			return nil // legit case
-		}
-		if !containsResource(nodeTopology, resName) {
-			return fmt.Errorf("the node topology data doesn't include resource %q", resName)
-		}
-		return nil
 	}).WithTimeout(time.Minute).WithPolling(5 * time.Second).Should(gomega.Succeed())
 
 	return nodeTopology

--- a/test/e2e/utils/pods/rtepod/rtepod.go
+++ b/test/e2e/utils/pods/rtepod/rtepod.go
@@ -18,11 +18,15 @@ limitations under the License.
 package rtepod
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -77,7 +81,8 @@ func FindRTEContainerName(rtePod *corev1.Pod) (string, error) {
 	return "", fmt.Errorf("no container uses %q as command or argument", rteExecutable)
 }
 
-func FindNotificationFilePath(rtePod *corev1.Pod) (string, error) {
+func FindNotificationFilePath(ctx context.Context, cli *kubernetes.Clientset, rtePod *corev1.Pod) (string, error) {
+	// try CLI args first (legacy)
 	for idx := 0; idx < len(rtePod.Spec.Containers); idx++ {
 		cnt := rtePod.Spec.Containers[idx] // shortcut
 		if len(cnt.Command) > 0 && strings.Contains(cnt.Command[0], rteExecutable) {
@@ -88,7 +93,39 @@ func FindNotificationFilePath(rtePod *corev1.Pod) (string, error) {
 			}
 		}
 	}
-	return "", fmt.Errorf("no container uses %q as an argument option", notificationFileOption)
+	return findNotifyFilePathFromConfigMap(ctx, cli, rtePod)
+}
+
+func findNotifyFilePathFromConfigMap(ctx context.Context, cli *kubernetes.Clientset, rtePod *corev1.Pod) (string, error) {
+	for _, vol := range rtePod.Spec.Volumes {
+		if vol.ConfigMap == nil {
+			continue
+		}
+		if !strings.Contains(vol.ConfigMap.Name, "daemon") {
+			continue
+		}
+		cm, err := cli.CoreV1().ConfigMaps(rtePod.Namespace).Get(ctx, vol.ConfigMap.Name, metav1.GetOptions{})
+		if err != nil {
+			return "", fmt.Errorf("failed to get configmap %q: %w", vol.ConfigMap.Name, err)
+		}
+		data, ok := cm.Data["config.yaml"]
+		if !ok {
+			continue
+		}
+		var cfg map[string]any
+		if err := yaml.Unmarshal([]byte(data), &cfg); err != nil {
+			continue
+		}
+		te, ok := cfg["topologyExporter"].(map[string]any)
+		if !ok {
+			continue
+		}
+		notifyPath, ok := te["notifyFilePath"].(string)
+		if ok && notifyPath != "" {
+			return notifyPath, nil
+		}
+	}
+	return "", fmt.Errorf("cannot find notification file path from CLI args or daemon configmap")
 }
 
 func isRTEContainer(cnt corev1.Container) bool {


### PR DESCRIPTION
Even though they will still be fully supported for the foreseeable future, we should use configfiles as default config mechanism. 

Update the example configuration.
This move highlighted some gaps in the config flags/file mapping, which are fixed in the same commit.