### PR TITLE
better support for multiple-instances on the same node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,10 +100,23 @@ dev-lint: _out/golangci-lint
 	$(GOLANGCI_LINT_BIN) run
 
 .PHONY: build-e2e
-build-e2e: _out/rte-e2e.test
+build-e2e: _out/rte-e2e.test _out/rte-lease-holder
 
 _out/rte-e2e.test: outdir test/e2e/*.go test/e2e/utils/*.go
 	go test -v -c -o _out/rte-e2e.test ./test/e2e/
+
+_out/rte-local-e2e.test: outdir test/e2e_local/*.go test/e2e/rte_local/*.go
+	go test -v -c -o _out/rte-local-e2e.test ./test/e2e_local/
+
+_out/rte-lease-holder: outdir test/e2e/tools/leaseholder/main.go
+	$(COMMONENVVAR) $(BUILDENVVAR) go build -o _out/rte-lease-holder ./test/e2e/tools/leaseholder/
+
+.PHONY: build-e2e-local
+build-e2e-local: _out/rte-local-e2e.test _out/rte-lease-holder
+
+.PHONY: test-e2e-local
+test-e2e-local: build-e2e-local build-rte
+	_out/rte-local-e2e.test -ginkgo.v -ginkgo.focus='\[RTE\]\[Local\]'
 
 .PHONY: test-e2e
 test-e2e: build-e2e

--- a/manifests/resource-topology-exporter.yaml
+++ b/manifests/resource-topology-exporter.yaml
@@ -90,6 +90,7 @@ spec:
       readinessGates:
         - conditionType: "PodresourcesFetched"
         - conditionType: "NodeTopologyUpdated"
+        - conditionType: "NodeUpdateLeaseHeld"
       serviceAccountName: rte
       containers:
       - name: resource-topology-exporter-container

--- a/pkg/config/cfgdispatch.go
+++ b/pkg/config/cfgdispatch.go
@@ -132,6 +132,7 @@ func dispatchConfObj(obj map[string]interface{}, pArgs *ProgArgs) error {
 		{key: "topologyExporter.notifyFilePath", out: &pArgs.RTE.NotifyFilePath},
 		{key: "topologyExporter.timeUnitToLimitEvents", out: &pArgs.RTE.TimeUnitToLimitEvents},
 		{key: "topologyExporter.addNRTOwnerEnable", out: &pArgs.RTE.AddNRTOwnerEnable},
+		{key: "topologyExporter.leaseFilePath", out: &pArgs.RTE.LeaseFilePath},
 		{key: "topologyExporter.metricsMode", out: &pArgs.RTE.MetricsMode},
 		{key: "topologyExporter.metricsPort", out: &pArgs.RTE.MetricsPort},
 		{key: "topologyExporter.metricsAddress", out: &pArgs.RTE.MetricsAddress},

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -71,6 +71,7 @@ func FromFlags(pArgs *ProgArgs, args ...string) (string, string, error) {
 	CommandLine.StringVar(&pArgs.RTE.PodResourcesSocketPath, "podresources-socket", pArgs.RTE.PodResourcesSocketPath, "Pod Resource Socket path to use.")
 	CommandLine.BoolVar(&pArgs.RTE.PodReadinessEnable, "podreadiness", pArgs.RTE.PodReadinessEnable, "Custom condition injection using Podreadiness.")
 	CommandLine.BoolVar(&pArgs.RTE.AddNRTOwnerEnable, "add-nrt-owner", pArgs.RTE.AddNRTOwnerEnable, "RTE will inject NRT's related node as OwnerReference to ensure cleanup if the node is deleted.")
+	CommandLine.StringVar(&pArgs.RTE.LeaseFilePath, "lease-file", pArgs.RTE.LeaseFilePath, "Path to the lease file. Use 'default' to derive from the notify file directory. Empty disables the lease.")
 	CommandLine.StringVar(&pArgs.RTE.MetricsMode, "metrics-mode", pArgs.RTE.MetricsMode, fmt.Sprintf("Select the mode to expose metrics endpoint. Valid options: %s", metricssrv.ServingModeSupported()))
 	CommandLine.IntVar(&pArgs.RTE.MetricsPort, "metrics-port", pArgs.RTE.MetricsPort, "Select the port to listen for the metrics endpoint.")
 	CommandLine.StringVar(&pArgs.RTE.MetricsAddress, "metrics-ip", pArgs.RTE.MetricsAddress, "Select the IP to listen for the metrics endpoint.")

--- a/pkg/nodelease/nodelease.go
+++ b/pkg/nodelease/nodelease.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package nodelease
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"k8s.io/klog/v2"
+)
+
+const LeaseFileName = "lease"
+
+const AutodetectLeaseFromNotify = "default"
+
+type Lease interface {
+	TryLock() bool
+	Close() error
+}
+
+type flockLease struct {
+	fd   int
+	path string
+	held bool
+}
+
+type nullLease struct{}
+
+// NewNull returns a no-op lease that always succeeds.
+func NewNull() Lease {
+	return &nullLease{}
+}
+
+func (hl *nullLease) TryLock() bool { return true }
+func (hl *nullLease) Close() error  { return nil }
+
+// New opens (or creates) the lease file at the given path.
+// The lock is NOT acquired until TryLock is called.
+func New(leaseFilePath string) (Lease, error) {
+	dir := filepath.Dir(leaseFilePath)
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return nil, fmt.Errorf("cannot create lease directory %q: %w", dir, err)
+	}
+
+	fd, err := syscall.Open(leaseFilePath, syscall.O_CREAT|syscall.O_RDWR, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open lease file %q: %w", leaseFilePath, err)
+	}
+	klog.Infof("nodelease: opened lease file %q (fd=%d)", leaseFilePath, fd)
+	return &flockLease{
+		fd:   fd,
+		path: leaseFilePath,
+	}, nil
+}
+
+// TryLock attempts to acquire the exclusive flock. If the lease is already
+// held by this instance, returns true immediately. If another process holds
+// the lock, returns false without blocking.
+func (nl *flockLease) TryLock() bool {
+	if nl.held {
+		return true
+	}
+	err := syscall.Flock(nl.fd, syscall.LOCK_EX|syscall.LOCK_NB)
+	if err != nil {
+		klog.V(4).Infof("nodelease: lease not acquired on %q: %v", nl.path, err)
+		return false
+	}
+	nl.held = true
+	klog.Infof("nodelease: acquired lease on %q", nl.path)
+	return true
+}
+
+// Close releases the flock (if held) by closing the file descriptor.
+func (nl *flockLease) Close() error {
+	err := syscall.Close(nl.fd)
+	if err != nil {
+		return fmt.Errorf("cannot close lease file %q: %w", nl.path, err)
+	}
+	nl.held = false
+	klog.Infof("nodelease: released lease on %q", nl.path)
+	return nil
+}
+
+// LeaseFilePath returns the default lease file path derived from the
+// notify file path. If notifyFilePath is empty, returns empty string.
+func LeaseFilePath(notifyFilePath string) string {
+	if notifyFilePath == "" {
+		return ""
+	}
+	return filepath.Join(filepath.Dir(notifyFilePath), LeaseFileName)
+}

--- a/pkg/nodelease/nodelease_test.go
+++ b/pkg/nodelease/nodelease_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package nodelease
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestTryLock_Acquires(t *testing.T) {
+	leaseFile := filepath.Join(t.TempDir(), "lease")
+	nl, err := New(leaseFile)
+	if err != nil {
+		t.Fatalf("failed to create NodeLease: %v", err)
+	}
+	defer nl.Close()
+
+	if !nl.TryLock() {
+		t.Fatal("expected TryLock to succeed on uncontested lease")
+	}
+}
+
+func TestTryLock_Idempotent(t *testing.T) {
+	leaseFile := filepath.Join(t.TempDir(), "lease")
+	nl, err := New(leaseFile)
+	if err != nil {
+		t.Fatalf("failed to create NodeLease: %v", err)
+	}
+	defer nl.Close()
+
+	if !nl.TryLock() {
+		t.Fatal("first TryLock should succeed")
+	}
+	if !nl.TryLock() {
+		t.Fatal("second TryLock should succeed (idempotent)")
+	}
+}
+
+func TestTryLock_Contention(t *testing.T) {
+	leaseFile := filepath.Join(t.TempDir(), "lease")
+	first, err := New(leaseFile)
+	if err != nil {
+		t.Fatalf("failed to create first NodeLease: %v", err)
+	}
+	defer first.Close()
+
+	if !first.TryLock() {
+		t.Fatal("first lock should succeed")
+	}
+
+	second, err := New(leaseFile)
+	if err != nil {
+		t.Fatalf("failed to create second NodeLease: %v", err)
+	}
+	defer second.Close()
+
+	if second.TryLock() {
+		t.Fatal("second lock should fail while first holds the lease")
+	}
+}
+
+func TestTryLock_ReleaseOnClose(t *testing.T) {
+	leaseFile := filepath.Join(t.TempDir(), "lease")
+	first, err := New(leaseFile)
+	if err != nil {
+		t.Fatalf("failed to create first NodeLease: %v", err)
+	}
+
+	if !first.TryLock() {
+		t.Fatal("first lock should succeed")
+	}
+
+	second, err := New(leaseFile)
+	if err != nil {
+		t.Fatalf("failed to create second NodeLease: %v", err)
+	}
+	defer second.Close()
+
+	if second.TryLock() {
+		t.Fatal("second lock should fail while first is held")
+	}
+
+	if err := first.Close(); err != nil {
+		t.Fatalf("failed to close first NodeLease: %v", err)
+	}
+
+	if !second.TryLock() {
+		t.Fatal("second lock should succeed after first is released")
+	}
+}
+
+func TestLeaseFilePath(t *testing.T) {
+	tests := []struct {
+		notifyPath string
+		expected   string
+	}{
+		{"/host-run/rte/notify", "/host-run/rte/lease"},
+		{"/var/run/rte/notify", "/var/run/rte/lease"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		got := LeaseFilePath(tc.notifyPath)
+		if got != tc.expected {
+			t.Errorf("LeaseFilePath(%q) = %q, want %q", tc.notifyPath, got, tc.expected)
+		}
+	}
+}

--- a/pkg/nrtupdater/nrtupdater.go
+++ b/pkg/nrtupdater/nrtupdater.go
@@ -212,7 +212,12 @@ func (te *NRTUpdater) patchNRT(ctx context.Context, cli topologyclientset.Interf
 	nrtUpdated, err := cli.TopologyV1alpha2().NodeResourceTopologies().Patch(ctx, te.prevNRT.Name, types.MergePatchType, patchInfo.Patch, metav1.PatchOptions{})
 	if err != nil {
 		metrics.UpdateNodeResourceTopologyPatchFailuresMetric("send_patch")
-		klog.Infof("failed to send a patch to the APIServer: %v", err)
+		if apierrors.IsConflict(err) {
+			te.prevNRT = nil
+			klog.Infof("conflict patching the APIServer, invalidating cached state: %v", err)
+		} else {
+			klog.Infof("failed to send a patch to the APIServer: %v", err)
+		}
 		return nil, err
 	}
 

--- a/pkg/nrtupdater/nrtupdater_test.go
+++ b/pkg/nrtupdater/nrtupdater_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -650,6 +651,99 @@ func TestPatchModeFallbackOnError(t *testing.T) {
 	nrtObj := obj.(*v1alpha2.NodeResourceTopology)
 	if !nrtObj.Zones[0].Resources[0].Available.Equal(resource.MustParse("8")) {
 		t.Errorf("expected Available=8 after fallback, got %v", nrtObj.Zones[0].Resources[0].Available.String())
+	}
+}
+
+func TestPatchModeConflictInvalidatesCache(t *testing.T) {
+	nodeName := "test-node"
+
+	args := Args{
+		Hostname:  nodeName,
+		PatchMode: true,
+	}
+	tmConfig := TMConfig{
+		Scope:  "scope-test",
+		Policy: "policy-test",
+	}
+
+	cli := fake.NewSimpleClientset()
+	k8sClient := clientk8sfake.NewSimpleClientset()
+	nodeGetter, err := NewCachedNodeGetter(k8sClient, context.Background())
+	if err != nil {
+		t.Fatalf("failed to create node getter: %v", err)
+	}
+	nrtUpd, err := NewNRTUpdater(nodeGetter, cli, args, tmConfig)
+	if err != nil {
+		t.Fatalf("failed to create NRT updater: %v", err)
+	}
+
+	zones := v1alpha2.ZoneList{
+		{
+			Name: "zone-0",
+			Type: "node",
+			Resources: v1alpha2.ResourceInfoList{
+				{
+					Name:        string(corev1.ResourceCPU),
+					Capacity:    resource.MustParse("16"),
+					Allocatable: resource.MustParse("14"),
+					Available:   resource.MustParse("14"),
+				},
+			},
+		},
+	}
+
+	// Bootstrap: create the object and populate prevNRT
+	err = nrtUpd.Update(context.TODO(), MonitorInfo{Zones: zones})
+	if err != nil {
+		t.Fatalf("bootstrap update failed: %v", err)
+	}
+
+	// Inject a conflict error on patch AND fail the update fallback too
+	cli.PrependReactor("patch", "noderesourcetopologies", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewConflict(nrtResource.GroupResource(), nodeName, fmt.Errorf("simulated conflict"))
+	})
+	cli.PrependReactor("update", "noderesourcetopologies", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("simulated update failure")
+	})
+
+	cli.ClearActions()
+
+	// Both patch (conflict) and update fallback fail
+	err = nrtUpd.Update(context.TODO(), MonitorInfo{Zones: zones})
+	if err == nil {
+		t.Fatalf("expected error when both patch and update fail")
+	}
+
+	verbs := nrtVerbs(cli.Actions())
+	if !reflect.DeepEqual(verbs, []string{"patch", "get", "update"}) {
+		t.Errorf("expected patch then fallback get+update, got verbs: %v", verbs)
+	}
+
+	// Remove all reactors so the next call succeeds
+	cli.ReactionChain = cli.ReactionChain[2:]
+	cli.ClearActions()
+
+	// Next cycle: prevNRT was invalidated by the conflict, so patchNRT
+	// returns ErrMissingPreviousNRT and falls back to update path
+	zones[0].Resources[0].Available = resource.MustParse("8")
+	err = nrtUpd.Update(context.TODO(), MonitorInfo{Zones: zones})
+	if err != nil {
+		t.Fatalf("recovery update should succeed: %v", err)
+	}
+
+	verbs = nrtVerbs(cli.Actions())
+	if !reflect.DeepEqual(verbs, []string{"get", "update"}) {
+		t.Errorf("after conflict invalidation, expected get+update (no patch attempt), got verbs: %v", verbs)
+	}
+
+	// Verify final state
+	obj, err := cli.Tracker().Get(nrtResource, "", nodeName)
+	if err != nil {
+		t.Fatalf("failed to get NRT after recovery: %v", err)
+	}
+	nrtObj := obj.(*v1alpha2.NodeResourceTopology)
+	if !nrtObj.Zones[0].Resources[0].Available.Equal(resource.MustParse("8")) {
+		t.Errorf("expected Available=8 after recovery, got %v", nrtObj.Zones[0].Resources[0].Available.String())
 	}
 }
 

--- a/pkg/podreadiness/condition.go
+++ b/pkg/podreadiness/condition.go
@@ -16,6 +16,9 @@ const (
 	PodresourcesFetched RTEConditionType = "PodresourcesFetched"
 	// NodeTopologyUpdated means that noderesourcetopology objects updated successfully.
 	NodeTopologyUpdated RTEConditionType = "NodeTopologyUpdated"
+	// NodeUpdateLeaseHeld means that this RTE instance holds the node-local lease
+	// and is actively pushing NRT updates.
+	NodeUpdateLeaseHeld RTEConditionType = "NodeUpdateLeaseHeld"
 )
 
 func SetCondition(condChan chan<- v1.PodCondition, condType RTEConditionType, condStatus v1.ConditionStatus) {
@@ -31,6 +34,9 @@ func SetCondition(condChan chan<- v1.PodCondition, condType RTEConditionType, co
 		case NodeTopologyUpdated:
 			cond.Reason = "UpdateFailed"
 			cond.Message = "failed to update noderesourcetopology object"
+		case NodeUpdateLeaseHeld:
+			cond.Reason = "LeaseNotHeld"
+			cond.Message = "waiting to acquire node-local lease"
 		}
 	}
 	condChan <- cond

--- a/pkg/resourcetopologyexporter/resourceobserver.go
+++ b/pkg/resourcetopologyexporter/resourceobserver.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/k8sannotations"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/metrics"
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/nodelease"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/notification"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/nrtupdater"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podreadiness"
@@ -22,9 +23,10 @@ type ResourceObserver struct {
 	infoChan        chan nrtupdater.MonitorInfo
 	stopChan        chan struct{}
 	exposeTiming    bool
+	nodeLease       nodelease.Lease
 }
 
-func NewResourceObserver(hnd resourcemonitor.Handle, args resourcemonitor.Args) (*ResourceObserver, error) {
+func NewResourceObserver(hnd resourcemonitor.Handle, args resourcemonitor.Args, nl nodelease.Lease) (*ResourceObserver, error) {
 	resMon, err := resourcemonitor.NewResourceMonitor(hnd, args)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize ResourceMonitor: %w", err)
@@ -36,6 +38,7 @@ func NewResourceObserver(hnd resourcemonitor.Handle, args resourcemonitor.Args) 
 		stopChan:        make(chan struct{}),
 		infoChan:        make(chan nrtupdater.MonitorInfo),
 		exposeTiming:    args.ExposeTiming,
+		nodeLease:       nl,
 	}
 	resObs.Infos = resObs.infoChan
 	return &resObs, nil
@@ -78,6 +81,13 @@ func (rm *ResourceObserver) Run(eventsChan <-chan notification.Event, condChan c
 				podreadiness.SetCondition(condChan, podreadiness.PodresourcesFetched, condStatus)
 				continue
 			}
+
+			if !rm.nodeLease.TryLock() {
+				podreadiness.SetCondition(condChan, podreadiness.NodeUpdateLeaseHeld, v1.ConditionFalse)
+				continue
+			}
+			podreadiness.SetCondition(condChan, podreadiness.NodeUpdateLeaseHeld, v1.ConditionTrue)
+
 			rm.infoChan <- monInfo
 
 			tsDiff := tsEnd.Sub(tsBegin)

--- a/pkg/resourcetopologyexporter/resourcetopologyexporter.go
+++ b/pkg/resourcetopologyexporter/resourcetopologyexporter.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/kubeconf"
 	metricssrv "github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/metrics/server"
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/nodelease"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/notification"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/nrtupdater"
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/podreadiness"
@@ -32,6 +33,7 @@ type Args struct {
 	MaxEventsPerTimeUnit   int64                          `json:"maxEventPerTimeUnit,omitempty"`
 	TimeUnitToLimitEvents  time.Duration                  `json:"timeUnitToLimitEvents,omitempty"`
 	AddNRTOwnerEnable      bool                           `json:"addNRTOwnerEnable,omitempty"`
+	LeaseFilePath          string                         `json:"leaseFilePath,omitempty"`
 	MetricsMode            string                         `json:"metricsMode,omitempty"`
 	MetricsPort            int                            `json:"metricsPort,omitempty"`
 	MetricsAddress         string                         `json:"metricsAddress,omitempty"`
@@ -51,6 +53,7 @@ func (args Args) Clone() Args {
 		MaxEventsPerTimeUnit:   args.MaxEventsPerTimeUnit,
 		TimeUnitToLimitEvents:  args.TimeUnitToLimitEvents,
 		AddNRTOwnerEnable:      args.AddNRTOwnerEnable,
+		LeaseFilePath:          args.LeaseFilePath,
 		MetricsMode:            args.MetricsMode,
 		MetricsPort:            args.MetricsPort,
 		MetricsAddress:         args.MetricsAddress,
@@ -99,7 +102,13 @@ func Execute(hnd Handle, nrtupdaterArgs nrtupdater.Args, resourcemonitorArgs res
 		return err
 	}
 
-	resObs, err := NewResourceObserver(hnd.ResMon, resourcemonitorArgs)
+	nl, err := createNodeLease(rteArgs)
+	if err != nil {
+		return err
+	}
+	defer nl.Close()
+
+	resObs, err := NewResourceObserver(hnd.ResMon, resourcemonitorArgs, nl)
 	if err != nil {
 		return err
 	}
@@ -175,4 +184,18 @@ func getTopologyManagerSettings(rteArgs Args) (tmSettings, error) {
 		return tmConf, nil
 	}
 	return tmSettings{}, fmt.Errorf("cannot find the kubelet Topology Manager policy")
+}
+
+func createNodeLease(rteArgs Args) (nodelease.Lease, error) {
+	if rteArgs.LeaseFilePath == "" {
+		return nodelease.NewNull(), nil
+	}
+	leaseFile := rteArgs.LeaseFilePath
+	if leaseFile == nodelease.AutodetectLeaseFromNotify {
+		leaseFile = nodelease.LeaseFilePath(rteArgs.NotifyFilePath)
+		if leaseFile == "" {
+			return nil, fmt.Errorf("lease file %q requested but no notify file path is set (set --notify-file or provide an explicit --lease-file path)", nodelease.AutodetectLeaseFromNotify)
+		}
+	}
+	return nodelease.New(leaseFile)
 }

--- a/test/e2e/rte_local/nodelease.go
+++ b/test/e2e/rte_local/nodelease.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rte_local
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/nodelease"
+
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/utils"
+)
+
+var _ = ginkgo.Describe("[RTE][Local][NodeLease] Node-local lease", func() {
+	var leaseDir string
+
+	ginkgo.BeforeEach(func() {
+		var err error
+		leaseDir, err = os.MkdirTemp("", "rte-lease-e2e-*")
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(os.RemoveAll(leaseDir)).To(gomega.Succeed())
+	})
+
+	ginkgo.It("[release] should allow a single holder to acquire the lease", func() {
+		leaseFile := filepath.Join(leaseDir, "lease")
+		nl, err := nodelease.New(leaseFile)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		defer nl.Close()
+
+		gomega.Expect(nl.TryLock()).To(gomega.BeTrue())
+	})
+
+	ginkgo.It("[release] should be idempotent when called multiple times", func() {
+		leaseFile := filepath.Join(leaseDir, "lease")
+		nl, err := nodelease.New(leaseFile)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		defer nl.Close()
+
+		gomega.Expect(nl.TryLock()).To(gomega.BeTrue())
+		gomega.Expect(nl.TryLock()).To(gomega.BeTrue())
+	})
+
+	ginkgo.It("[release] should prevent a second holder from acquiring the same lease", func() {
+		leaseFile := filepath.Join(leaseDir, "lease")
+
+		first, err := nodelease.New(leaseFile)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		defer first.Close()
+		gomega.Expect(first.TryLock()).To(gomega.BeTrue())
+
+		second, err := nodelease.New(leaseFile)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		defer second.Close()
+		gomega.Expect(second.TryLock()).To(gomega.BeFalse())
+	})
+
+	ginkgo.It("[release] should release the lease on Close and allow another holder", func() {
+		leaseFile := filepath.Join(leaseDir, "lease")
+
+		first, err := nodelease.New(leaseFile)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(first.TryLock()).To(gomega.BeTrue())
+
+		second, err := nodelease.New(leaseFile)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		defer second.Close()
+
+		gomega.Expect(second.TryLock()).To(gomega.BeFalse())
+
+		gomega.Expect(first.Close()).To(gomega.Succeed())
+		gomega.Expect(second.TryLock()).To(gomega.BeTrue())
+	})
+
+	ginkgo.It("[release] should release the lease when the holding process is killed", func() {
+		leaseFile := filepath.Join(leaseDir, "lease")
+
+		helperBin := filepath.Join(utils.BinariesPath, "rte-lease-holder")
+		child := exec.Command(helperBin, leaseFile)
+		child.Stdout = ginkgo.GinkgoWriter
+		child.Stderr = ginkgo.GinkgoWriter
+
+		err := child.Start()
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		fmt.Fprintf(ginkgo.GinkgoWriter, "started lease holder process pid=%d\n", child.Process.Pid)
+
+		// give the child time to acquire
+		time.Sleep(500 * time.Millisecond)
+
+		nl, err := nodelease.New(leaseFile)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		defer nl.Close()
+
+		gomega.Expect(nl.TryLock()).To(gomega.BeFalse(), "should not acquire lease while child holds it")
+		fmt.Fprintf(ginkgo.GinkgoWriter, "correctly failed to acquire lease (child holds it)\n")
+
+		gomega.Expect(child.Process.Kill()).To(gomega.Succeed())
+		child.Wait()
+		fmt.Fprintf(ginkgo.GinkgoWriter, "child process killed\n")
+
+		gomega.Expect(nl.TryLock()).To(gomega.BeTrue(), "should acquire lease after child is killed")
+		fmt.Fprintf(ginkgo.GinkgoWriter, "acquired lease after child death\n")
+	})
+})

--- a/test/e2e/tools/leaseholder/main.go
+++ b/test/e2e/tools/leaseholder/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/nodelease"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s <lease-file-path>\n", os.Args[0])
+		os.Exit(1)
+	}
+	nl, err := nodelease.New(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create lease: %v\n", err)
+		os.Exit(1)
+	}
+	if !nl.TryLock() {
+		fmt.Fprintf(os.Stderr, "failed to acquire lease\n")
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stdout, "lease acquired, holding until killed\n")
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	<-sig
+}

--- a/test/e2e_local/e2e_local_suite_test.go
+++ b/test/e2e_local/e2e_local_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_local
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	_ "github.com/k8stopologyawareschedwg/resource-topology-exporter/test/e2e/rte_local"
+)
+
+func TestE2ELocal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "E2E Local Suite")
+}


### PR DESCRIPTION
In order to support upgrade flows, turns out we actually need to support a temporary but non-zero window on which more than a RTE is  running on a node.

This requirement breaks some very key and very old design assumptions, but the saving grace is that RTEs are mostly stateless, all the instance observe the same state and patch mode is the default but not part of a stable release yet.

Add better support for this very scenario: more resilient patch mode, handling confilicts, and node-local inter-RTE basic lease. We don't use proper battle-tested kubernetes leases because the scenario we guard against is expected to be limited and time-bound, so a simpler solution has merit, and reduces the apiserver load.
