### PR TITLE
ctxlog: port ResourceMonitor to contextual logging

### DIFF
--- a/cmd/resource-topology-exporter/main.go
+++ b/cmd/resource-topology-exporter/main.go
@@ -76,9 +76,11 @@ func main() {
 		cli = podexclude.NewFromLister(cli, parsedArgs.Global.Debug, parsedArgs.Resourcemonitor.PodExclude)
 	}
 
+	ctx := context.Background()
+
 	if parsedArgs.Resourcemonitor.ExcludeTerminalPods {
 		klog.Infof("terminal pods are filtered from the PodResourcesLister client")
-		cli, err = terminalpods.NewFromLister(context.TODO(), cli, k8scli, time.Minute, parsedArgs.Global.Debug)
+		cli, err = terminalpods.NewFromLister(ctx, cli, k8scli, time.Minute, parsedArgs.Global.Debug)
 		if err != nil {
 			klog.Fatalf("failed to get PodResourceAPI client: %v", err)
 		}
@@ -94,7 +96,6 @@ func main() {
 	}
 
 	if parsedArgs.Resourcemonitor.PodSetFingerprint {
-		ctx := context.TODO()
 		hnd := pfpdump.Handle{
 			Dumpfile: parsedArgs.Resourcemonitor.PodSetFingerprintStatusFile,
 		}
@@ -108,7 +109,7 @@ func main() {
 		},
 		NRTCli: nrtcli,
 	}
-	err = resourcetopologyexporter.Execute(hnd, parsedArgs.NRTupdater, parsedArgs.Resourcemonitor, parsedArgs.RTE)
+	err = resourcetopologyexporter.Execute(ctx, hnd, parsedArgs.NRTupdater, parsedArgs.Resourcemonitor, parsedArgs.RTE)
 	if err != nil {
 		klog.Fatalf("failed to execute: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/fsnotify/fsnotify v1.9.0
+	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
 	github.com/jaypipes/ghw v0.21.3-0.20260109185716-ee0aed93f45d
 	github.com/jeremywohl/flatten/v2 v2.0.0-20211013061545-07e4a09fb8e4
@@ -45,7 +46,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect

--- a/pkg/resourcemonitor/resourcemonitor.go
+++ b/pkg/resourcemonitor/resourcemonitor.go
@@ -36,6 +36,8 @@ import (
 	"k8s.io/klog/v2"
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 
+	"github.com/go-logr/logr"
+
 	ghwoption "github.com/jaypipes/ghw/pkg/option"
 	ghwtopology "github.com/jaypipes/ghw/pkg/topology"
 	"github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
@@ -188,6 +190,7 @@ type resourceMonitor struct {
 	coreIDToNodeIDMap map[int]int
 	nodeCapacity      perNUMAResourceCounter
 	nodeAllocatable   perNUMAResourceCounter
+	scanIteration     uint64
 }
 
 func NewResourceMonitor(hnd Handle, args Args, tmPolicy string, options ...func(*resourceMonitor)) *resourceMonitor {
@@ -208,8 +211,15 @@ func NewResourceMonitor(hnd Handle, args Args, tmPolicy string, options ...func(
 	return rm
 }
 
+func (rm *resourceMonitor) GetScanIteration() string {
+	val := rm.scanIteration
+	rm.scanIteration++
+	return fmt.Sprintf("%v", val)
+}
+
 func (rm *resourceMonitor) Setup(ctx context.Context) error {
-	klog.Infof("resmon: starting for node %q", rm.nodeName)
+	logger := klog.FromContext(ctx).WithValues("node", rm.nodeName)
+	logger.Info("starting")
 
 	if rm.topo == nil {
 		topo, err := ghwtopology.New(ghwoption.WithPathOverrides(ghwoption.PathOverrides{
@@ -220,30 +230,30 @@ func (rm *resourceMonitor) Setup(ctx context.Context) error {
 		}
 		rm.topo = topo
 	}
-	klog.V(4).Infof("resmon: machine topology: %s", toJSON(rm.topo))
+	logger.V(4).Info("machine topology", "topology", toJSON(rm.topo))
 
 	rm.coreIDToNodeIDMap = MakeCoreIDToNodeIDMap(rm.topo)
-	klog.V(4).Infof("resmon: CPU mapping [coreid:numaid]: %s", mapIntIntToString(rm.coreIDToNodeIDMap))
+	logger.V(4).Info("CPU mapping", "coreIDToNodeID", mapIntIntToString(rm.coreIDToNodeIDMap))
 
 	if err := rm.updateNodeResources(ctx); err != nil {
 		return err
 	}
-	klog.V(2).Infof("resmon: initial capacity for node %q: %s", rm.nodeName, rm.nodeCapacity)
-	klog.V(2).Infof("resmon: initial allocatable for node %q: %s", rm.nodeName, rm.nodeAllocatable)
+	logger.V(2).Info("initial capacity", "capacity", rm.nodeCapacity)
+	logger.V(2).Info("initial allocatable", "allocatable", rm.nodeAllocatable)
 
 	if !rm.args.RefreshNodeResources {
-		klog.Infof("resmon: getting node resources once")
+		logger.Info("getting node resources once")
 	} else {
-		klog.Infof("resmon: tracking node resources")
+		logger.Info("tracking node resources")
 		if err := addNodeInformerEvent(rm.k8sCli, cache.ResourceEventHandlerFuncs{UpdateFunc: rm.resUpdated}); err != nil {
 			return err
 		}
 	}
 
 	if rm.args.Namespace != "" {
-		klog.Infof("resmon: watching namespace %q", rm.args.Namespace)
+		logger.Info("watching namespace", "namespace", rm.args.Namespace)
 	} else {
-		klog.Infof("resmon: watching all namespaces")
+		logger.Info("watching all namespaces")
 	}
 	return nil
 }
@@ -272,6 +282,8 @@ func (rm *resourceMonitor) HasTopologyManagerPolicy(policy string) bool {
 
 // Scan scans the node pods using podresources API, processes the scan response and builds up the returned value.
 func (rm *resourceMonitor) Scan(ctx context.Context, excludeList ResourceExclude) (ScanResponse, error) {
+	logger := klog.FromContext(ctx).WithName("resmon").WithValues("scanID", rm.GetScanIteration())
+
 	ctx, cancel := context.WithTimeout(ctx, defaultPodResourcesTimeout)
 	defer cancel()
 	resp, err := rm.podResCli.List(ctx, &podresourcesapi.ListPodResourcesRequest{})
@@ -281,7 +293,7 @@ func (rm *resourceMonitor) Scan(ctx context.Context, excludeList ResourceExclude
 	}
 
 	respRawPodRes := resp.GetPodResources()
-	klog.V(6).Infof("resmon: raw podresources list: %s", stringifyPodResources(respRawPodRes))
+	logger.V(6).Info("raw podresources list", "podresources", stringifyPodResources(respRawPodRes))
 
 	numaEligiblePodRes := []*podresourcesapi.PodResources{}
 	var sb strings.Builder
@@ -295,7 +307,7 @@ func (rm *resourceMonitor) Scan(ctx context.Context, excludeList ResourceExclude
 		sep = "  "
 		numaEligiblePodRes = append(numaEligiblePodRes, pr)
 	}
-	klog.V(6).Infof("resmon: numa eligible podresources list: %s", sb.String())
+	logger.V(6).Info("numa eligible podresources list", "podresources", sb.String())
 
 	scanRes := ScanResponse{
 		Attributes:  topologyv1alpha2.AttributeList{},
@@ -319,25 +331,25 @@ func (rm *resourceMonitor) Scan(ctx context.Context, excludeList ResourceExclude
 			Value: rm.args.PodSetFingerprintMethod,
 		})
 		scanRes.Annotations[podfingerprint.Annotation] = pfpSign
-		klog.V(6).Infof("resmon: pfp: %s", st.Repr())
+		logger.V(6).Info("pod fingerprint", "status", st.Repr())
 
 		podfingerprint.MarkCompleted(st)
 
 		// numaplacement encoding is only done for pods that are eligible for NUMA placement (with
 		// exclusive resources), which are a subset of pods that are participating in PFP (it is
 		// not always the same pods as PFP because it depends on the filter function used)
-		payload = ComputeNUMAPlacementPayload(numaEligiblePodRes, rm.tmPolicy, len(rm.topo.Nodes), rm.coreIDToNodeIDMap)
+		payload = ComputeNUMAPlacementPayload(logger, numaEligiblePodRes, rm.tmPolicy, len(rm.topo.Nodes), rm.coreIDToNodeIDMap)
 		if payload != nil {
 			metadata := payload.PackMetadata()
 			scanRes.Attributes = append(scanRes.Attributes, topologyv1alpha2.AttributeInfo{
 				Name:  numaplacement.AttributeMetadata,
 				Value: metadata,
 			})
-			klog.V(6).Infof("resmon: numaplacement metadata: %s", metadata)
+			logger.V(6).Info("numaplacement metadata", "metadata", metadata)
 		}
 	}
-	allDevs := GetAllContainerDevices(respRawPodRes, rm.args.Namespace, rm.coreIDToNodeIDMap)
-	allocated := ContainerDevicesToPerNUMAResourceCounters(allDevs)
+	allDevs := GetAllContainerDevices(logger, respRawPodRes, rm.args.Namespace, rm.coreIDToNodeIDMap)
+	allocated := ContainerDevicesToPerNUMAResourceCounters(logger, allDevs)
 
 	excludeSet := excludeList.ToMapSet()
 	zones := make(topologyv1alpha2.ZoneList, 0, len(rm.topo.Nodes))
@@ -363,7 +375,7 @@ func (rm *resourceMonitor) Scan(ctx context.Context, excludeList ResourceExclude
 
 		costs, err := makeCostsPerNumaNode(rm.topo.Nodes, nodeID)
 		if err != nil {
-			klog.Warningf("resmon: cannot find costs for NUMA node %d: %v", nodeID, err)
+			logger.V(1).Info("cannot find costs for NUMA node", "nodeID", nodeID, "err", err)
 		} else {
 			zone.Costs = costs
 		}
@@ -398,13 +410,13 @@ func (rm *resourceMonitor) Scan(ctx context.Context, excludeList ResourceExclude
 				// in case of non-native resources, let's tolerate and let's log only when very high levels are requested.
 				// In these cases the admin knows there could be A LOT of data in the logs.
 				if isNativeResource(resName) {
-					klog.Warningf("resmon: zero capacity for native resource %q on NUMA cell %d", resName, nodeID)
+					logger.V(1).Info("zero capacity for native resource", "resource", resName, "numaCell", nodeID)
 				} else {
-					klog.V(5).Infof("resmon: zero capacity for extra resource %q on NUMA cell %d", resName, nodeID)
+					logger.V(5).Info("zero capacity for extra resource", "resource", resName, "numaCell", nodeID)
 				}
 			}
 			if resAlloc > resCapacity {
-				klog.Warningf("resmon: allocated more than capacity for %q on zone %q", resName.String(), zone.Name)
+				logger.V(1).Info("allocated more than capacity", "resource", resName, "zone", zone.Name)
 				// we trust more kubelet than ourselves atm.
 				resCapacity = resAlloc
 			}
@@ -413,7 +425,7 @@ func (rm *resourceMonitor) Scan(ctx context.Context, excludeList ResourceExclude
 
 			resAvail := resAlloc - resUsed
 			if resAvail < 0 {
-				klog.Warningf("resmon: negative size for %q on zone %q", resName.String(), zone.Name)
+				logger.V(1).Info("negative size", "resource", resName, "zone", zone.Name)
 				resAvail = 0
 			}
 
@@ -431,23 +443,23 @@ func (rm *resourceMonitor) Scan(ctx context.Context, excludeList ResourceExclude
 	return scanRes, nil
 }
 
-func ComputeNUMAPlacementPayload(numaEligiblePodRes []*podresourcesapi.PodResources, topologyManagerPolicy string, nodesCount int, coreIDToNodeIDMap map[int]int) *numaplacement.Payload {
+func ComputeNUMAPlacementPayload(logger logr.Logger, numaEligiblePodRes []*podresourcesapi.PodResources, topologyManagerPolicy string, nodesCount int, coreIDToNodeIDMap map[int]int) *numaplacement.Payload {
 	// computing payload is valuable only on singleNumaNode policy because only under that
 	// condition there will be 1:1 stable mapping between the containers to the NUMA nodes.
 	if topologyManagerPolicy != TopologyManagerPolicySingleNUMANode {
-		klog.V(4).Infof("resmon: topology manager policy %q is not supported for NUMA placement", topologyManagerPolicy)
+		logger.V(4).Info("topology manager policy not supported for NUMA placement", "policy", topologyManagerPolicy)
 		return nil
 	}
 
 	enc, err := numaplacement.NewEncoder(nodesCount)
 	if err != nil {
-		klog.ErrorS(err, "resmon: while creating NUMA placement encoder")
+		logger.Error(err, "while creating NUMA placement encoder")
 		return nil
 	}
 
 	// Important:the consumer should apply the same filter on the pods' containers to be able
 	// to properly decode the attributes' values.
-	klog.V(4).Infof("resmon: collecting containers that are eligible for NUMA placement")
+	logger.V(4).Info("collecting containers that are eligible for NUMA placement")
 	for _, pr := range numaEligiblePodRes {
 		for _, cnt := range pr.Containers {
 			cntID := numaplacement.ContainerID{
@@ -457,7 +469,7 @@ func ComputeNUMAPlacementPayload(numaEligiblePodRes []*podresourcesapi.PodResour
 			}
 			numaNodeID, err := getContainerSingleNUMAPlacement(cnt, coreIDToNodeIDMap)
 			if err != nil {
-				klog.ErrorS(err, "resmon: while getting container NUMA placement", "ident", cntID.String())
+				logger.Error(err, "while getting container NUMA placement", "ident", cntID.String())
 				return nil
 			}
 			if numaNodeID == -1 {
@@ -471,7 +483,7 @@ func ComputeNUMAPlacementPayload(numaEligiblePodRes []*podresourcesapi.PodResour
 				NUMANode: numaNodeID,
 			})
 			if err != nil {
-				klog.ErrorS(err, "resmon: while encoding container NUMA affinity", "ident", cntID.String())
+				logger.Error(err, "while encoding container NUMA affinity", "ident", cntID.String())
 				return nil
 			}
 		}
@@ -479,7 +491,7 @@ func ComputeNUMAPlacementPayload(numaEligiblePodRes []*podresourcesapi.PodResour
 
 	payload, err := enc.Result()
 	if err != nil {
-		klog.ErrorS(err, "resmon: while getting NUMA placement encoder result")
+		logger.Error(err, "while getting NUMA placement encoder result")
 		return nil
 	}
 	return &payload
@@ -517,17 +529,18 @@ func (rm *resourceMonitor) resUpdated(old, new interface{}) {
 		return
 	}
 
-	// the status frequency update are configurable via the node-status-update-frequency option in Kubelet
 	if !reflect.DeepEqual(nOld.Status.Capacity, nNew.Status.Capacity) ||
 		!reflect.DeepEqual(nOld.Status.Allocatable, nNew.Status.Allocatable) {
-		klog.V(2).Infof("resmon: update node resources")
+		logger := klog.TODO()
+		logger.V(2).Info("update node resources")
 		if err := rm.updateNodeResources(context.TODO()); err != nil {
-			klog.ErrorS(err, "resmon: while updating node resources")
+			logger.Error(err, "while updating node resources")
 		}
 	}
 }
 
 func (rm *resourceMonitor) updateNodeAllocatable(ctx context.Context) error {
+	logger := klog.FromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, defaultPodResourcesTimeout)
 	defer cancel()
 	allocRes, err := rm.podResCli.GetAllocatableResources(ctx, &podresourcesapi.AllocatableResourcesRequest{})
@@ -536,8 +549,8 @@ func (rm *resourceMonitor) updateNodeAllocatable(ctx context.Context) error {
 		return err
 	}
 
-	allDevs := NormalizeContainerDevices(klog.V(4), allocRes.GetDevices(), allocRes.GetMemory(), allocRes.GetCpuIds(), rm.coreIDToNodeIDMap)
-	rm.nodeAllocatable = ContainerDevicesToPerNUMAResourceCounters(allDevs)
+	allDevs := NormalizeContainerDevices(logger, allocRes.GetDevices(), allocRes.GetMemory(), allocRes.GetCpuIds(), rm.coreIDToNodeIDMap)
+	rm.nodeAllocatable = ContainerDevicesToPerNUMAResourceCounters(logger, allDevs)
 	return nil
 }
 
@@ -596,15 +609,14 @@ func stringifyPodResources(podRes []*podresourcesapi.PodResources) string {
 }
 
 // GetAllContainerDevices is deprecated and will be unexported in a future version
-func GetAllContainerDevices(podRes []*podresourcesapi.PodResources, namespace string, coreIDToNodeIDMap map[int]int) []*podresourcesapi.ContainerDevices {
+func GetAllContainerDevices(logger logr.Logger, podRes []*podresourcesapi.PodResources, namespace string, coreIDToNodeIDMap map[int]int) []*podresourcesapi.ContainerDevices {
 	allCntRes := []*podresourcesapi.ContainerDevices{}
 	for _, pr := range podRes {
-		// filter by namespace (if given)
 		if namespace != "" && namespace != pr.GetNamespace() {
 			continue
 		}
 		for _, cnt := range pr.GetContainers() {
-			allCntRes = append(allCntRes, NormalizeContainerDevices(klog.V(8), cnt.GetDevices(), cnt.GetMemory(), cnt.GetCpuIds(), coreIDToNodeIDMap)...)
+			allCntRes = append(allCntRes, NormalizeContainerDevices(logger, cnt.GetDevices(), cnt.GetMemory(), cnt.GetCpuIds(), coreIDToNodeIDMap)...)
 		}
 	}
 	return allCntRes
@@ -622,25 +634,24 @@ func ComputePodFingerprint(podRes []*podresourcesapi.PodResources, st *podfinger
 	return fp.Sign()
 }
 
-func NormalizeContainerDevices(lh klog.Verbose, devices []*podresourcesapi.ContainerDevices, memoryBlocks []*podresourcesapi.ContainerMemory, cpuIds []int64, coreIDToNodeIDMap map[int]int) []*podresourcesapi.ContainerDevices {
-	lh.Infof("normalizing container devices: from devices=%d memoryBlocks=%d CPUs=%d", len(devices), len(memoryBlocks), len(cpuIds))
+func NormalizeContainerDevices(logger logr.Logger, devices []*podresourcesapi.ContainerDevices, memoryBlocks []*podresourcesapi.ContainerMemory, cpuIds []int64, coreIDToNodeIDMap map[int]int) []*podresourcesapi.ContainerDevices {
+	logger.V(4).Info("normalizing container devices", "devices", len(devices), "memoryBlocks", len(memoryBlocks), "CPUs", len(cpuIds))
 
-	lh.Infof("normalize Devices count=%d", len(devices))
+	logger.V(4).Info("normalize devices", "count", len(devices))
 	contDevs := append([]*podresourcesapi.ContainerDevices{}, devices...)
 
 	cpusPerNuma := make(map[int][]string)
 	for _, cpuID := range cpuIds {
 		nodeID, ok := coreIDToNodeIDMap[int(cpuID)]
 		if !ok {
-			// this must be logged unconditionally, so we use klog directly
-			klog.Warningf("resmon: cannot find the NUMA node for CPU %d", cpuID)
+			logger.V(1).Info("cannot find the NUMA node for CPU", "cpuID", cpuID)
 			continue
 		}
 		cpusPerNuma[nodeID] = append(cpusPerNuma[nodeID], fmt.Sprintf("%d", cpuID))
 	}
 
 	for nodeID, cpuList := range cpusPerNuma {
-		lh.Infof("normalize CPUs NUMANode=%d, count=%d", nodeID, len(cpuList))
+		logger.V(4).Info("normalize CPUs", "numaNode", nodeID, "count", len(cpuList))
 		contDevs = append(contDevs, &podresourcesapi.ContainerDevices{
 			ResourceName: string(v1.ResourceCPU),
 			DeviceIds:    cpuList,
@@ -659,7 +670,7 @@ func NormalizeContainerDevices(lh klog.Verbose, devices []*podresourcesapi.Conta
 		}
 
 		for _, node := range block.GetTopology().GetNodes() {
-			lh.Infof("normalize MemoryBlocks NUMANode=%d size=%v", node.ID, blockSize)
+			logger.V(4).Info("normalize memory blocks", "numaNode", node.ID, "size", blockSize)
 			contDevs = append(contDevs, &podresourcesapi.ContainerDevices{
 				ResourceName: block.MemoryType,
 				DeviceIds:    []string{fmt.Sprintf("%d", blockSize)},
@@ -672,11 +683,11 @@ func NormalizeContainerDevices(lh klog.Verbose, devices []*podresourcesapi.Conta
 		}
 	}
 
-	lh.Infof("normalized container devices: entries=%d from devices=%d memoryBlocks=%d CPUs=%d", len(contDevs), len(devices), len(memoryBlocks), len(cpuIds))
+	logger.V(4).Info("normalized container devices", "entries", len(contDevs), "devices", len(devices), "memoryBlocks", len(memoryBlocks), "CPUs", len(cpuIds))
 	return contDevs
 }
 
-func ContainerDevicesToPerNUMAResourceCounters(devices []*podresourcesapi.ContainerDevices) perNUMAResourceCounter {
+func ContainerDevicesToPerNUMAResourceCounters(logger logr.Logger, devices []*podresourcesapi.ContainerDevices) perNUMAResourceCounter {
 	perNUMARc := make(perNUMAResourceCounter)
 	for _, device := range devices {
 		resourceName := device.GetResourceName()
@@ -700,7 +711,7 @@ func ContainerDevicesToPerNUMAResourceCounters(devices []*podresourcesapi.Contai
 			perNUMARc[nodeID] = nodeRes
 		}
 	}
-	klog.V(6).Infof("resmon: from devices=%d: %s", len(devices), perNUMARc.String())
+	logger.V(6).Info("container devices to per-NUMA resource counters", "devices", len(devices), "counters", perNUMARc.String())
 	return perNUMARc
 }
 

--- a/pkg/resourcemonitor/resourcemonitor.go
+++ b/pkg/resourcemonitor/resourcemonitor.go
@@ -129,8 +129,8 @@ func (sr ScanResponse) SortedZones() v1alpha2.ZoneList {
 }
 
 type ResourceMonitor interface {
-	Setup() error
-	Scan(excludeList ResourceExclude) (ScanResponse, error)
+	Setup(ctx context.Context) error
+	Scan(ctx context.Context, excludeList ResourceExclude) (ScanResponse, error)
 }
 
 // ToMapSet keeps the original keys, but replaces values with set.String types
@@ -208,7 +208,7 @@ func NewResourceMonitor(hnd Handle, args Args, tmPolicy string, options ...func(
 	return rm
 }
 
-func (rm *resourceMonitor) Setup() error {
+func (rm *resourceMonitor) Setup(ctx context.Context) error {
 	klog.Infof("resmon: starting for node %q", rm.nodeName)
 
 	if rm.topo == nil {
@@ -225,7 +225,7 @@ func (rm *resourceMonitor) Setup() error {
 	rm.coreIDToNodeIDMap = MakeCoreIDToNodeIDMap(rm.topo)
 	klog.V(4).Infof("resmon: CPU mapping [coreid:numaid]: %s", mapIntIntToString(rm.coreIDToNodeIDMap))
 
-	if err := rm.updateNodeResources(); err != nil {
+	if err := rm.updateNodeResources(ctx); err != nil {
 		return err
 	}
 	klog.V(2).Infof("resmon: initial capacity for node %q: %s", rm.nodeName, rm.nodeCapacity)
@@ -271,8 +271,8 @@ func (rm *resourceMonitor) HasTopologyManagerPolicy(policy string) bool {
 }
 
 // Scan scans the node pods using podresources API, processes the scan response and builds up the returned value.
-func (rm *resourceMonitor) Scan(excludeList ResourceExclude) (ScanResponse, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultPodResourcesTimeout)
+func (rm *resourceMonitor) Scan(ctx context.Context, excludeList ResourceExclude) (ScanResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, defaultPodResourcesTimeout)
 	defer cancel()
 	resp, err := rm.podResCli.List(ctx, &podresourcesapi.ListPodResourcesRequest{})
 	if err != nil {
@@ -521,14 +521,14 @@ func (rm *resourceMonitor) resUpdated(old, new interface{}) {
 	if !reflect.DeepEqual(nOld.Status.Capacity, nNew.Status.Capacity) ||
 		!reflect.DeepEqual(nOld.Status.Allocatable, nNew.Status.Allocatable) {
 		klog.V(2).Infof("resmon: update node resources")
-		if err := rm.updateNodeResources(); err != nil {
+		if err := rm.updateNodeResources(context.TODO()); err != nil {
 			klog.ErrorS(err, "resmon: while updating node resources")
 		}
 	}
 }
 
-func (rm *resourceMonitor) updateNodeAllocatable() error {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultPodResourcesTimeout)
+func (rm *resourceMonitor) updateNodeAllocatable(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, defaultPodResourcesTimeout)
 	defer cancel()
 	allocRes, err := rm.podResCli.GetAllocatableResources(ctx, &podresourcesapi.AllocatableResourcesRequest{})
 	if err != nil {
@@ -553,11 +553,11 @@ func (rm *resourceMonitor) updateDevicesCapacity() {
 	}
 }
 
-func (rm *resourceMonitor) updateNodeResources() error {
+func (rm *resourceMonitor) updateNodeResources(ctx context.Context) error {
 	if err := rm.updateNodeCapacity(); err != nil {
 		return fmt.Errorf("error while updating node capacity: %w", err)
 	}
-	if err := rm.updateNodeAllocatable(); err != nil {
+	if err := rm.updateNodeAllocatable(ctx); err != nil {
 		return fmt.Errorf("error while updating node allocatable: %w", err)
 	}
 	// there is no trivial way to detect devices capacity from the node.

--- a/pkg/resourcemonitor/resourcemonitor.go
+++ b/pkg/resourcemonitor/resourcemonitor.go
@@ -296,18 +296,15 @@ func (rm *resourceMonitor) Scan(ctx context.Context, excludeList ResourceExclude
 	logger.V(6).Info("raw podresources list", "podresources", stringifyPodResources(respRawPodRes))
 
 	numaEligiblePodRes := []*podresourcesapi.PodResources{}
-	var sb strings.Builder
-	sep := ""
 	for _, pr := range respRawPodRes {
 		nl := numalocfilter.Verify(pr)
 		if !nl.Allow {
+			logger.V(8).Info("podresources item: not eligible for NUMA", "pod", pr.Namespace+"/"+pr.Name, "ident", nl.Ident, "reason", nl.Reason)
 			continue
 		}
-		sb.WriteString(sep + pr.Namespace + "/" + pr.Name + "/" + nl.Ident + "=" + nl.Reason)
-		sep = "  "
 		numaEligiblePodRes = append(numaEligiblePodRes, pr)
 	}
-	logger.V(6).Info("numa eligible podresources list", "podresources", sb.String())
+	logger.V(6).Info("NUMA eligible podresources list", "podresources", stringifyPodResources(numaEligiblePodRes))
 
 	scanRes := ScanResponse{
 		Attributes:  topologyv1alpha2.AttributeList{},

--- a/pkg/resourcemonitor/resourcemonitor.go
+++ b/pkg/resourcemonitor/resourcemonitor.go
@@ -129,6 +129,7 @@ func (sr ScanResponse) SortedZones() v1alpha2.ZoneList {
 }
 
 type ResourceMonitor interface {
+	Setup() error
 	Scan(excludeList ResourceExclude) (ScanResponse, error)
 }
 
@@ -189,7 +190,7 @@ type resourceMonitor struct {
 	nodeAllocatable   perNUMAResourceCounter
 }
 
-func NewResourceMonitor(hnd Handle, args Args, tmPolicy string, options ...func(*resourceMonitor)) (*resourceMonitor, error) {
+func NewResourceMonitor(hnd Handle, args Args, tmPolicy string, options ...func(*resourceMonitor)) *resourceMonitor {
 	rm := &resourceMonitor{
 		podResCli: hnd.PodResCli,
 		k8sCli:    hnd.K8SCli,
@@ -204,14 +205,18 @@ func NewResourceMonitor(hnd Handle, args Args, tmPolicy string, options ...func(
 		rm.nodeName = os.Getenv("NODE_NAME")
 	}
 
+	return rm
+}
+
+func (rm *resourceMonitor) Setup() error {
 	klog.Infof("resmon: starting for node %q", rm.nodeName)
 
 	if rm.topo == nil {
 		topo, err := ghwtopology.New(ghwoption.WithPathOverrides(ghwoption.PathOverrides{
-			"/sys": args.SysfsRoot,
+			"/sys": rm.args.SysfsRoot,
 		}))
 		if err != nil {
-			return nil, err
+			return err
 		}
 		rm.topo = topo
 	}
@@ -221,7 +226,7 @@ func NewResourceMonitor(hnd Handle, args Args, tmPolicy string, options ...func(
 	klog.V(4).Infof("resmon: CPU mapping [coreid:numaid]: %s", mapIntIntToString(rm.coreIDToNodeIDMap))
 
 	if err := rm.updateNodeResources(); err != nil {
-		return nil, err
+		return err
 	}
 	klog.V(2).Infof("resmon: initial capacity for node %q: %s", rm.nodeName, rm.nodeCapacity)
 	klog.V(2).Infof("resmon: initial allocatable for node %q: %s", rm.nodeName, rm.nodeAllocatable)
@@ -231,7 +236,7 @@ func NewResourceMonitor(hnd Handle, args Args, tmPolicy string, options ...func(
 	} else {
 		klog.Infof("resmon: tracking node resources")
 		if err := addNodeInformerEvent(rm.k8sCli, cache.ResourceEventHandlerFuncs{UpdateFunc: rm.resUpdated}); err != nil {
-			return nil, err
+			return err
 		}
 	}
 
@@ -240,7 +245,7 @@ func NewResourceMonitor(hnd Handle, args Args, tmPolicy string, options ...func(
 	} else {
 		klog.Infof("resmon: watching all namespaces")
 	}
-	return rm, nil
+	return nil
 }
 
 func WithTopology(topo *ghwtopology.Info) func(*resourceMonitor) {

--- a/pkg/resourcemonitor/resourcemonitor_test.go
+++ b/pkg/resourcemonitor/resourcemonitor_test.go
@@ -26,9 +26,10 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/klog/v2"
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 	v1 "k8s.io/kubelet/pkg/apis/podresources/v1"
+
+	"github.com/go-logr/logr"
 
 	cmp "github.com/google/go-cmp/cmp"
 	ghwtopology "github.com/jaypipes/ghw/pkg/topology"
@@ -186,8 +187,7 @@ func TestNormalizeContainerDevices(t *testing.T) {
 	coreIDToNodeIDMap := getExpectedCoreToNodeMap()
 
 	Convey("When normalizing the container devices from pod resources", t, func() {
-		VL := klog.V(999) // so high that means "never" in practice
-		res := NormalizeContainerDevices(VL, availRes.GetDevices(), availRes.GetMemory(), availRes.GetCpuIds(), coreIDToNodeIDMap)
+		res := NormalizeContainerDevices(logr.Discard(), availRes.GetDevices(), availRes.GetMemory(), availRes.GetCpuIds(), coreIDToNodeIDMap)
 		expected := []*podresourcesapi.ContainerDevices{
 			{
 				ResourceName: "fake.io/net",
@@ -1663,7 +1663,7 @@ func TestScanNUMAPlacementAttributes(t *testing.T) {
 
 func TestComputeNUMAPlacementPayload(t *testing.T) {
 	Convey("When the topology manager policy is not a single-numa-node (not supported for numaplacement encoding)", t, func() {
-		payload := ComputeNUMAPlacementPayload([]*podresourcesapi.PodResources{
+		payload := ComputeNUMAPlacementPayload(logr.Discard(), []*podresourcesapi.PodResources{
 			{Containers: []*podresourcesapi.ContainerResources{
 				{CpuIds: []int64{0}},
 			}},
@@ -1674,7 +1674,7 @@ func TestComputeNUMAPlacementPayload(t *testing.T) {
 	Convey("When the topology manager policy is single-numa-node", t, func() {
 		Convey("With zero pods", func() {
 			numaCount := 2
-			payload := ComputeNUMAPlacementPayload([]*podresourcesapi.PodResources{}, TopologyManagerPolicySingleNUMANode, numaCount, getExpectedCoreToNodeMap())
+			payload := ComputeNUMAPlacementPayload(logr.Discard(), []*podresourcesapi.PodResources{}, TopologyManagerPolicySingleNUMANode, numaCount, getExpectedCoreToNodeMap())
 			assert.NotNil(t, payload)
 			assert.Equal(t, 0, payload.Containers)
 			assert.Equal(t, 0, payload.BusiestNode)
@@ -1710,7 +1710,7 @@ func TestComputeNUMAPlacementPayload(t *testing.T) {
 				},
 			}
 			numaCount := 2
-			payload := ComputeNUMAPlacementPayload(pods, TopologyManagerPolicySingleNUMANode, numaCount, getExpectedCoreToNodeMap())
+			payload := ComputeNUMAPlacementPayload(logr.Discard(), pods, TopologyManagerPolicySingleNUMANode, numaCount, getExpectedCoreToNodeMap())
 			assert.NotNil(t, payload)
 			assert.Equal(t, 2, payload.Containers)
 			assert.Equal(t, 1, payload.BusiestNode)

--- a/pkg/resourcemonitor/resourcemonitor_test.go
+++ b/pkg/resourcemonitor/resourcemonitor_test.go
@@ -463,7 +463,8 @@ func TestResourcesScan(t *testing.T) {
 
 		mockPodResClient := new(podres.MockPodResourcesListerClient)
 		mockPodResClient.On("GetAllocatableResources", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.AllocatableResourcesRequest")).Return(availRes, nil)
-		resMon, err := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{}, "", WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
+		resMon := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{}, "", WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
+		err := resMon.Setup()
 		So(err, ShouldBeNil)
 
 		Convey("When aggregating resources", func() {
@@ -560,7 +561,8 @@ func TestResourcesScan(t *testing.T) {
 
 		mockPodResClient := new(podres.MockPodResourcesListerClient)
 		mockPodResClient.On("GetAllocatableResources", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.AllocatableResourcesRequest")).Return(availRes, nil)
-		resMon, err := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{}, "", WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
+		resMon := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{}, "", WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
+		err := resMon.Setup()
 		So(err, ShouldBeNil)
 
 		Convey("When aggregating resources", func() {
@@ -713,7 +715,8 @@ func TestResourcesScan(t *testing.T) {
 
 		mockPodResClient := new(podres.MockPodResourcesListerClient)
 		mockPodResClient.On("GetAllocatableResources", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.AllocatableResourcesRequest")).Return(allocRes, nil)
-		resMon, err := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{}, "", WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
+		resMon := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{}, "", WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
+		err := resMon.Setup()
 		So(err, ShouldBeNil)
 
 		Convey("When aggregating resources", func() {
@@ -884,7 +887,8 @@ func TestResourcesScan(t *testing.T) {
 
 		mockPodResClient := new(podres.MockPodResourcesListerClient)
 		mockPodResClient.On("GetAllocatableResources", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.AllocatableResourcesRequest")).Return(allocRes, nil)
-		resMon, err := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{}, "", WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
+		resMon := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{}, "", WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
+		err := resMon.Setup()
 		So(err, ShouldBeNil)
 
 		Convey("When aggregating resources", func() {
@@ -1107,7 +1111,8 @@ func TestResourcesScan(t *testing.T) {
 		}
 		mockPodResClient := new(podres.MockPodResourcesListerClient)
 		mockPodResClient.On("GetAllocatableResources", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.AllocatableResourcesRequest")).Return(allocRes, nil)
-		resMon, err := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{RefreshNodeResources: true}, "", WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
+		resMon := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{RefreshNodeResources: true}, "", WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
+		err := resMon.Setup()
 		So(err, ShouldBeNil)
 
 		Convey("When aggregating resources", func() {
@@ -1277,7 +1282,8 @@ func TestResourcesScan(t *testing.T) {
 
 		mockPodResClient := new(podres.MockPodResourcesListerClient)
 		mockPodResClient.On("GetAllocatableResources", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.AllocatableResourcesRequest")).Return(availRes, nil)
-		resMon, err := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{PodSetFingerprint: true}, "", WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
+		resMon := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{PodSetFingerprint: true}, "", WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
+		err := resMon.Setup()
 		So(err, ShouldBeNil)
 
 		Convey("When aggregating resources", func() {
@@ -1375,7 +1381,7 @@ func TestNewResourceMonitorTMConfig(t *testing.T) {
 		Return(&v1.AllocatableResourcesResponse{}, nil)
 
 	tmPolicy := "single-numa-node"
-	rm, err := NewResourceMonitor(
+	rm := NewResourceMonitor(
 		Handle{PodResCli: mockPodResClient},
 		Args{},
 		tmPolicy,
@@ -1383,7 +1389,7 @@ func TestNewResourceMonitorTMConfig(t *testing.T) {
 		WithTopology(&topo),
 		WithK8sClient(fake.NewSimpleClientset()),
 	)
-	assert.NoError(t, err)
+	assert.NoError(t, rm.Setup())
 	assert.True(t, rm.HasTopologyManagerPolicy(tmPolicy))
 }
 
@@ -1518,7 +1524,7 @@ func TestScanNUMAPlacementAttributes(t *testing.T) {
 		}
 		mockPodResClient := newPodResMock(listResp)
 
-		resMon, err := NewResourceMonitor(
+		resMon := NewResourceMonitor(
 			Handle{PodResCli: mockPodResClient},
 			Args{
 				PodSetFingerprint:       true,
@@ -1528,6 +1534,7 @@ func TestScanNUMAPlacementAttributes(t *testing.T) {
 			WithNodeName("TEST"),
 			WithTopology(&fakeTopo),
 			WithK8sClient(fake.NewSimpleClientset()))
+		err := resMon.Setup()
 		So(err, ShouldBeNil)
 
 		scanRes, err := resMon.Scan(ResourceExclude{})
@@ -1575,7 +1582,7 @@ func TestScanNUMAPlacementAttributes(t *testing.T) {
 		}
 		mockPodResClient := newPodResMock(listResp)
 
-		rm, err := NewResourceMonitor(
+		rm := NewResourceMonitor(
 			Handle{PodResCli: mockPodResClient},
 			Args{
 				PodSetFingerprint:       true,
@@ -1585,7 +1592,7 @@ func TestScanNUMAPlacementAttributes(t *testing.T) {
 			WithNodeName("TEST"),
 			WithTopology(&fakeTopo),
 			WithK8sClient(fake.NewSimpleClientset()))
-		assert.NoError(t, err)
+		assert.NoError(t, rm.Setup())
 
 		scanRes, err := rm.Scan(ResourceExclude{})
 		assert.NoError(t, err)
@@ -1611,7 +1618,7 @@ func TestScanNUMAPlacementAttributes(t *testing.T) {
 		}
 		mockPodResClient := newPodResMock(listResp)
 
-		rm, err := NewResourceMonitor(
+		rm := NewResourceMonitor(
 			Handle{PodResCli: mockPodResClient},
 			Args{
 				PodSetFingerprint:       true,
@@ -1621,7 +1628,7 @@ func TestScanNUMAPlacementAttributes(t *testing.T) {
 			WithNodeName("TEST"),
 			WithTopology(&fakeTopo),
 			WithK8sClient(fake.NewSimpleClientset()))
-		assert.NoError(t, err)
+		assert.NoError(t, rm.Setup())
 
 		scanRes, err := rm.Scan(ResourceExclude{})
 		assert.NoError(t, err)
@@ -1634,14 +1641,14 @@ func TestScanNUMAPlacementAttributes(t *testing.T) {
 
 	Convey("When PFP is disabled, no NUMA placement metadata is added", t, func() {
 		mockPodResClient := newPodResMock(&podresourcesapi.ListPodResourcesResponse{})
-		rm, err := NewResourceMonitor(
+		rm := NewResourceMonitor(
 			Handle{PodResCli: mockPodResClient},
 			Args{PodSetFingerprint: false},
 			TopologyManagerPolicySingleNUMANode,
 			WithNodeName("TEST"),
 			WithTopology(&fakeTopo),
 			WithK8sClient(fake.NewSimpleClientset()))
-		assert.NoError(t, err)
+		assert.NoError(t, rm.Setup())
 
 		scanRes, err := rm.Scan(ResourceExclude{})
 		assert.NoError(t, err)

--- a/pkg/resourcemonitor/resourcemonitor_test.go
+++ b/pkg/resourcemonitor/resourcemonitor_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resourcemonitor
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"sort"
@@ -464,7 +465,7 @@ func TestResourcesScan(t *testing.T) {
 		mockPodResClient := new(podres.MockPodResourcesListerClient)
 		mockPodResClient.On("GetAllocatableResources", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.AllocatableResourcesRequest")).Return(availRes, nil)
 		resMon := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{}, "", WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
-		err := resMon.Setup()
+		err := resMon.Setup(context.TODO())
 		So(err, ShouldBeNil)
 
 		Convey("When aggregating resources", func() {
@@ -537,7 +538,7 @@ func TestResourcesScan(t *testing.T) {
 				PodResources: []*v1.PodResources{},
 			}
 			mockPodResClient.On("List", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.ListPodResourcesRequest")).Return(resp, nil)
-			scanRes, err := resMon.Scan(ResourceExclude{}) // no pods allocation
+			scanRes, err := resMon.Scan(context.TODO(), ResourceExclude{}) // no pods allocation
 			So(err, ShouldBeNil)
 
 			res := scanRes.SortedZones()
@@ -562,7 +563,7 @@ func TestResourcesScan(t *testing.T) {
 		mockPodResClient := new(podres.MockPodResourcesListerClient)
 		mockPodResClient.On("GetAllocatableResources", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.AllocatableResourcesRequest")).Return(availRes, nil)
 		resMon := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{}, "", WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
-		err := resMon.Setup()
+		err := resMon.Setup(context.TODO())
 		So(err, ShouldBeNil)
 
 		Convey("When aggregating resources", func() {
@@ -635,7 +636,7 @@ func TestResourcesScan(t *testing.T) {
 				PodResources: []*v1.PodResources{},
 			}
 			mockPodResClient.On("List", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.ListPodResourcesRequest")).Return(resp, nil)
-			scanRes, err := resMon.Scan(ResourceExclude{}) // no pods allocation
+			scanRes, err := resMon.Scan(context.TODO(), ResourceExclude{}) // no pods allocation
 			So(err, ShouldBeNil)
 
 			res := scanRes.SortedZones()
@@ -716,7 +717,7 @@ func TestResourcesScan(t *testing.T) {
 		mockPodResClient := new(podres.MockPodResourcesListerClient)
 		mockPodResClient.On("GetAllocatableResources", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.AllocatableResourcesRequest")).Return(allocRes, nil)
 		resMon := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{}, "", WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
-		err := resMon.Setup()
+		err := resMon.Setup(context.TODO())
 		So(err, ShouldBeNil)
 
 		Convey("When aggregating resources", func() {
@@ -832,7 +833,7 @@ func TestResourcesScan(t *testing.T) {
 			}
 
 			mockPodResClient.On("List", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.ListPodResourcesRequest")).Return(resp, nil)
-			scanRes, err := resMon.Scan(excludeList)
+			scanRes, err := resMon.Scan(context.TODO(), excludeList)
 			So(err, ShouldBeNil)
 
 			res := scanRes.Zones.DeepCopy()
@@ -888,7 +889,7 @@ func TestResourcesScan(t *testing.T) {
 		mockPodResClient := new(podres.MockPodResourcesListerClient)
 		mockPodResClient.On("GetAllocatableResources", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.AllocatableResourcesRequest")).Return(allocRes, nil)
 		resMon := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{}, "", WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
-		err := resMon.Setup()
+		err := resMon.Setup(context.TODO())
 		So(err, ShouldBeNil)
 
 		Convey("When aggregating resources", func() {
@@ -1004,7 +1005,7 @@ func TestResourcesScan(t *testing.T) {
 			}
 
 			mockPodResClient.On("List", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.ListPodResourcesRequest")).Return(resp, nil)
-			scanRes, err := resMon.Scan(excludeList)
+			scanRes, err := resMon.Scan(context.TODO(), excludeList)
 			So(err, ShouldBeNil)
 
 			res := scanRes.Zones.DeepCopy()
@@ -1112,7 +1113,7 @@ func TestResourcesScan(t *testing.T) {
 		mockPodResClient := new(podres.MockPodResourcesListerClient)
 		mockPodResClient.On("GetAllocatableResources", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.AllocatableResourcesRequest")).Return(allocRes, nil)
 		resMon := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{RefreshNodeResources: true}, "", WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
-		err := resMon.Setup()
+		err := resMon.Setup(context.TODO())
 		So(err, ShouldBeNil)
 
 		Convey("When aggregating resources", func() {
@@ -1228,7 +1229,7 @@ func TestResourcesScan(t *testing.T) {
 			}
 
 			mockPodResClient.On("List", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.ListPodResourcesRequest")).Return(resp, nil)
-			scanRes, err := resMon.Scan(excludeList)
+			scanRes, err := resMon.Scan(context.TODO(), excludeList)
 			So(err, ShouldBeNil)
 
 			res := scanRes.Zones.DeepCopy()
@@ -1283,7 +1284,7 @@ func TestResourcesScan(t *testing.T) {
 		mockPodResClient := new(podres.MockPodResourcesListerClient)
 		mockPodResClient.On("GetAllocatableResources", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.AllocatableResourcesRequest")).Return(availRes, nil)
 		resMon := NewResourceMonitor(Handle{PodResCli: mockPodResClient}, Args{PodSetFingerprint: true}, "", WithNodeName("TEST"), WithTopology(&fakeTopo), WithK8sClient(fake.NewSimpleClientset()))
-		err := resMon.Setup()
+		err := resMon.Setup(context.TODO())
 		So(err, ShouldBeNil)
 
 		Convey("When aggregating resources", func() {
@@ -1359,7 +1360,7 @@ func TestResourcesScan(t *testing.T) {
 
 			mockPodResClient.On("GetAllocatableResources", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.AllocatableResourcesRequest")).Return(allocRes, nil)
 			mockPodResClient.On("List", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.ListPodResourcesRequest")).Return(resp, nil)
-			scanRes, err := resMon.Scan(ResourceExclude{})
+			scanRes, err := resMon.Scan(context.TODO(), ResourceExclude{})
 
 			expectedFP := "pfp0v001fe53c4dbd2c5f4a0" // pre-computed and validated manually
 			fp, ok := scanRes.Annotations[podfingerprint.Annotation]
@@ -1389,7 +1390,7 @@ func TestNewResourceMonitorTMConfig(t *testing.T) {
 		WithTopology(&topo),
 		WithK8sClient(fake.NewSimpleClientset()),
 	)
-	assert.NoError(t, rm.Setup())
+	assert.NoError(t, rm.Setup(context.TODO()))
 	assert.True(t, rm.HasTopologyManagerPolicy(tmPolicy))
 }
 
@@ -1534,10 +1535,10 @@ func TestScanNUMAPlacementAttributes(t *testing.T) {
 			WithNodeName("TEST"),
 			WithTopology(&fakeTopo),
 			WithK8sClient(fake.NewSimpleClientset()))
-		err := resMon.Setup()
+		err := resMon.Setup(context.TODO())
 		So(err, ShouldBeNil)
 
-		scanRes, err := resMon.Scan(ResourceExclude{})
+		scanRes, err := resMon.Scan(context.TODO(), ResourceExclude{})
 		So(err, ShouldBeNil)
 
 		metaVal, ok := scanAttributeValue(scanRes.Attributes, numaplacement.AttributeMetadata)
@@ -1592,9 +1593,9 @@ func TestScanNUMAPlacementAttributes(t *testing.T) {
 			WithNodeName("TEST"),
 			WithTopology(&fakeTopo),
 			WithK8sClient(fake.NewSimpleClientset()))
-		assert.NoError(t, rm.Setup())
+		assert.NoError(t, rm.Setup(context.TODO()))
 
-		scanRes, err := rm.Scan(ResourceExclude{})
+		scanRes, err := rm.Scan(context.TODO(), ResourceExclude{})
 		assert.NoError(t, err)
 
 		_, ok := scanAttributeValue(scanRes.Attributes, numaplacement.AttributeMetadata)
@@ -1628,9 +1629,9 @@ func TestScanNUMAPlacementAttributes(t *testing.T) {
 			WithNodeName("TEST"),
 			WithTopology(&fakeTopo),
 			WithK8sClient(fake.NewSimpleClientset()))
-		assert.NoError(t, rm.Setup())
+		assert.NoError(t, rm.Setup(context.TODO()))
 
-		scanRes, err := rm.Scan(ResourceExclude{})
+		scanRes, err := rm.Scan(context.TODO(), ResourceExclude{})
 		assert.NoError(t, err)
 
 		_, ok := scanAttributeValue(scanRes.Attributes, numaplacement.AttributeMetadata)
@@ -1648,9 +1649,9 @@ func TestScanNUMAPlacementAttributes(t *testing.T) {
 			WithNodeName("TEST"),
 			WithTopology(&fakeTopo),
 			WithK8sClient(fake.NewSimpleClientset()))
-		assert.NoError(t, rm.Setup())
+		assert.NoError(t, rm.Setup(context.TODO()))
 
-		scanRes, err := rm.Scan(ResourceExclude{})
+		scanRes, err := rm.Scan(context.TODO(), ResourceExclude{})
 		assert.NoError(t, err)
 
 		_, ok := scanAttributeValue(scanRes.Attributes, numaplacement.AttributeMetadata)

--- a/pkg/resourcetopologyexporter/resourceobserver.go
+++ b/pkg/resourcetopologyexporter/resourceobserver.go
@@ -1,6 +1,7 @@
 package resourcetopologyexporter
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -26,7 +27,7 @@ type ResourceObserver struct {
 
 func NewResourceObserver(hnd resourcemonitor.Handle, args resourcemonitor.Args, tmPolicy string) (*ResourceObserver, error) {
 	resMon := resourcemonitor.NewResourceMonitor(hnd, args, tmPolicy)
-	if err := resMon.Setup(); err != nil {
+	if err := resMon.Setup(context.TODO()); err != nil {
 		return nil, fmt.Errorf("failed to setup ResourceMonitor: %w", err)
 	}
 
@@ -59,7 +60,7 @@ func (rm *ResourceObserver) Run(eventsChan <-chan notification.Event, condChan c
 			metrics.UpdateWakeupDelayMetric(monInfo.UpdateReason(), float64(tsWakeupDiff.Milliseconds()))
 
 			tsBegin := time.Now()
-			scanRes, err := rm.resMon.Scan(rm.resourceExclude)
+			scanRes, err := rm.resMon.Scan(context.TODO(), rm.resourceExclude)
 			tsEnd := time.Now()
 
 			monInfo.Annotations = scanRes.Annotations

--- a/pkg/resourcetopologyexporter/resourceobserver.go
+++ b/pkg/resourcetopologyexporter/resourceobserver.go
@@ -25,9 +25,9 @@ type ResourceObserver struct {
 }
 
 func NewResourceObserver(hnd resourcemonitor.Handle, args resourcemonitor.Args, tmPolicy string) (*ResourceObserver, error) {
-	resMon, err := resourcemonitor.NewResourceMonitor(hnd, args, tmPolicy)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize ResourceMonitor: %w", err)
+	resMon := resourcemonitor.NewResourceMonitor(hnd, args, tmPolicy)
+	if err := resMon.Setup(); err != nil {
+		return nil, fmt.Errorf("failed to setup ResourceMonitor: %w", err)
 	}
 
 	resObs := ResourceObserver{

--- a/pkg/resourcetopologyexporter/resourceobserver.go
+++ b/pkg/resourcetopologyexporter/resourceobserver.go
@@ -2,7 +2,6 @@ package resourcetopologyexporter
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -25,12 +24,7 @@ type ResourceObserver struct {
 	exposeTiming    bool
 }
 
-func NewResourceObserver(hnd resourcemonitor.Handle, args resourcemonitor.Args, tmPolicy string) (*ResourceObserver, error) {
-	resMon := resourcemonitor.NewResourceMonitor(hnd, args, tmPolicy)
-	if err := resMon.Setup(context.TODO()); err != nil {
-		return nil, fmt.Errorf("failed to setup ResourceMonitor: %w", err)
-	}
-
+func NewResourceObserver(resMon resourcemonitor.ResourceMonitor, args resourcemonitor.Args) *ResourceObserver {
 	resObs := ResourceObserver{
 		resMon:          resMon,
 		resourceExclude: args.ResourceExclude,
@@ -39,7 +33,7 @@ func NewResourceObserver(hnd resourcemonitor.Handle, args resourcemonitor.Args, 
 		exposeTiming:    args.ExposeTiming,
 	}
 	resObs.Infos = resObs.infoChan
-	return &resObs, nil
+	return &resObs
 }
 
 func (rm *ResourceObserver) Stop() {

--- a/pkg/resourcetopologyexporter/resourceobserver.go
+++ b/pkg/resourcetopologyexporter/resourceobserver.go
@@ -40,7 +40,7 @@ func (rm *ResourceObserver) Stop() {
 	rm.stopChan <- struct{}{}
 }
 
-func (rm *ResourceObserver) Run(eventsChan <-chan notification.Event, condChan chan<- v1.PodCondition) {
+func (rm *ResourceObserver) Run(ctx context.Context, eventsChan <-chan notification.Event, condChan chan<- v1.PodCondition) {
 	lastWakeup := time.Now()
 	for {
 		select {
@@ -54,7 +54,7 @@ func (rm *ResourceObserver) Run(eventsChan <-chan notification.Event, condChan c
 			metrics.UpdateWakeupDelayMetric(monInfo.UpdateReason(), float64(tsWakeupDiff.Milliseconds()))
 
 			tsBegin := time.Now()
-			scanRes, err := rm.resMon.Scan(context.TODO(), rm.resourceExclude)
+			scanRes, err := rm.resMon.Scan(ctx, rm.resourceExclude)
 			tsEnd := time.Now()
 
 			monInfo.Annotations = scanRes.Annotations
@@ -78,6 +78,8 @@ func (rm *ResourceObserver) Run(eventsChan <-chan notification.Event, condChan c
 			tsDiff := tsEnd.Sub(tsBegin)
 			metrics.UpdateOperationDelayMetric("podresources_scan", monInfo.UpdateReason(), float64(tsDiff.Milliseconds()))
 			podreadiness.SetCondition(condChan, podreadiness.PodresourcesFetched, condStatus)
+		case <-ctx.Done():
+			return
 		case <-rm.stopChan:
 			klog.Infof("read stop at %v", time.Now())
 			return

--- a/pkg/resourcetopologyexporter/resourcetopologyexporter.go
+++ b/pkg/resourcetopologyexporter/resourcetopologyexporter.go
@@ -99,10 +99,15 @@ func Execute(hnd Handle, nrtupdaterArgs nrtupdater.Args, resourcemonitorArgs res
 		return err
 	}
 
-	resObs, err := NewResourceObserver(hnd.ResMon, resourcemonitorArgs, tmConf.config.Policy)
-	if err != nil {
-		return err
+	ctx := context.Background()
+
+	resMon := resourcemonitor.NewResourceMonitor(hnd.ResMon, resourcemonitorArgs, tmConf.config.Policy)
+	if err := resMon.Setup(ctx); err != nil {
+		return fmt.Errorf("failed to setup ResourceMonitor: %w", err)
 	}
+
+	resObs := NewResourceObserver(resMon, resourcemonitorArgs)
+
 	go resObs.Run(eventSource.Events(), condChan)
 
 	upd, err := nrtupdater.NewNRTUpdater(nodeGetter, hnd.NRTCli, nrtupdaterArgs, tmConf.config)

--- a/pkg/resourcetopologyexporter/resourcetopologyexporter.go
+++ b/pkg/resourcetopologyexporter/resourcetopologyexporter.go
@@ -67,7 +67,7 @@ type Handle struct {
 	NRTCli topologyclientset.Interface
 }
 
-func Execute(hnd Handle, nrtupdaterArgs nrtupdater.Args, resourcemonitorArgs resourcemonitor.Args, rteArgs Args) error {
+func Execute(ctx context.Context, hnd Handle, nrtupdaterArgs nrtupdater.Args, resourcemonitorArgs resourcemonitor.Args, rteArgs Args) error {
 	tmConf, err := getTopologyManagerSettings(rteArgs)
 	if err != nil {
 		return err
@@ -75,7 +75,7 @@ func Execute(hnd Handle, nrtupdaterArgs nrtupdater.Args, resourcemonitorArgs res
 
 	var nodeGetter nrtupdater.NodeGetter
 	if rteArgs.AddNRTOwnerEnable {
-		nodeGetter, err = nrtupdater.NewCachedNodeGetter(hnd.ResMon.K8SCli, context.Background())
+		nodeGetter, err = nrtupdater.NewCachedNodeGetter(hnd.ResMon.K8SCli, ctx)
 		if err != nil {
 			klog.V(2).Info("Cannot enable 'add-nrt-owner'. Unable to get node info")
 			return fmt.Errorf("Cannot enable 'add-nrt-owner'. %w", err)
@@ -91,15 +91,13 @@ func Execute(hnd Handle, nrtupdaterArgs nrtupdater.Args, resourcemonitorArgs res
 		if err != nil {
 			return err
 		}
-		go condIn.Run(context.Background(), condChan)
+		go condIn.Run(ctx, condChan)
 	}
 
 	eventSource, err := createEventSource(&rteArgs)
 	if err != nil {
 		return err
 	}
-
-	ctx := context.Background()
 
 	resMon := resourcemonitor.NewResourceMonitor(hnd.ResMon, resourcemonitorArgs, tmConf.config.Policy)
 	if err := resMon.Setup(ctx); err != nil {
@@ -108,7 +106,7 @@ func Execute(hnd Handle, nrtupdaterArgs nrtupdater.Args, resourcemonitorArgs res
 
 	resObs := NewResourceObserver(resMon, resourcemonitorArgs)
 
-	go resObs.Run(eventSource.Events(), condChan)
+	go resObs.Run(ctx, eventSource.Events(), condChan)
 
 	upd, err := nrtupdater.NewNRTUpdater(nodeGetter, hnd.NRTCli, nrtupdaterArgs, tmConf.config)
 	if err != nil {
@@ -118,9 +116,13 @@ func Execute(hnd Handle, nrtupdaterArgs nrtupdater.Args, resourcemonitorArgs res
 
 	go eventSource.Run()
 
-	eventSource.Wait()  // will never return
-	eventSource.Close() // still we try to clean after ourselves :)
-	return nil          // unreachable
+	select {
+	case <-ctx.Done():
+	}
+	eventSource.Stop()
+	eventSource.Wait()
+	eventSource.Close()
+	return nil
 }
 
 func createEventSource(rteArgs *Args) (notification.EventSource, error) {


### PR DESCRIPTION
begin the transition to contextual logging by porting the `resourcemonitor` package.
This enables us to remove some technical debt (lack of `context` wiring) and simplify the logging.
We will continue with the contextual logging transition with more followup PRs.