### PR TITLE
ctxlog: wire and use context the in the resourcetopologyexporter package

### DIFF
--- a/pkg/resourcemonitor/resourcemonitor.go
+++ b/pkg/resourcemonitor/resourcemonitor.go
@@ -245,7 +245,9 @@ func (rm *resourceMonitor) Setup(ctx context.Context) error {
 		logger.Info("getting node resources once")
 	} else {
 		logger.Info("tracking node resources")
-		if err := addNodeInformerEvent(rm.k8sCli, cache.ResourceEventHandlerFuncs{UpdateFunc: rm.resUpdated}); err != nil {
+		if err := addNodeInformerEvent(ctx, rm.k8sCli, cache.ResourceEventHandlerFuncs{UpdateFunc: func(old, new any) {
+			rm.resUpdated(ctx, old, new)
+		}}); err != nil {
 			return err
 		}
 	}
@@ -518,7 +520,8 @@ func (rm *resourceMonitor) updateNodeCapacity() error {
 	return nil
 }
 
-func (rm *resourceMonitor) resUpdated(old, new interface{}) {
+func (rm *resourceMonitor) resUpdated(ctx context.Context, old, new any) {
+	logger := klog.FromContext(ctx)
 	nOld := old.(*v1.Node)
 	nNew := new.(*v1.Node)
 
@@ -528,9 +531,8 @@ func (rm *resourceMonitor) resUpdated(old, new interface{}) {
 
 	if !reflect.DeepEqual(nOld.Status.Capacity, nNew.Status.Capacity) ||
 		!reflect.DeepEqual(nOld.Status.Allocatable, nNew.Status.Allocatable) {
-		logger := klog.TODO()
 		logger.V(2).Info("update node resources")
-		if err := rm.updateNodeResources(context.TODO()); err != nil {
+		if err := rm.updateNodeResources(ctx); err != nil {
 			logger.Error(err, "while updating node resources")
 		}
 	}
@@ -774,11 +776,10 @@ func cpuCapacity(topo *ghwtopology.Info, nodeID int) int64 {
 	return int64(logicalCoresPerNUMA)
 }
 
-func addNodeInformerEvent(c kubernetes.Interface, handler cache.ResourceEventHandlerFuncs) error {
+func addNodeInformerEvent(ctx context.Context, c kubernetes.Interface, handler cache.ResourceEventHandlerFuncs) error {
 	factory := informers.NewSharedInformerFactory(c, 0)
 	nodeInformer := factory.Core().V1().Nodes().Informer()
 	_, _ = nodeInformer.AddEventHandler(handler)
-	ctx := context.Background()
 	factory.Start(ctx.Done())
 	if !cache.WaitForCacheSync(ctx.Done(), nodeInformer.HasSynced) {
 		return fmt.Errorf("timed out waiting for caches to sync")
@@ -815,7 +816,7 @@ func mapIntIntToString(mii map[int]int) string {
 	return sb.String()
 }
 
-func toJSON(obj interface{}) string {
+func toJSON(obj any) string {
 	data, err := json.Marshal(obj)
 	if err != nil {
 		return "<ERROR>"

--- a/pkg/resourcetopologyexporter/resourceobserver.go
+++ b/pkg/resourcetopologyexporter/resourceobserver.go
@@ -41,6 +41,7 @@ func (rm *ResourceObserver) Stop() {
 }
 
 func (rm *ResourceObserver) Run(ctx context.Context, eventsChan <-chan notification.Event, condChan chan<- v1.PodCondition) {
+	logger := klog.FromContext(ctx)
 	lastWakeup := time.Now()
 	for {
 		select {
@@ -68,7 +69,7 @@ func (rm *ResourceObserver) Run(ctx context.Context, eventsChan <-chan notificat
 
 			condStatus := v1.ConditionTrue
 			if err != nil {
-				klog.Warningf("failed to scan pod resources: %v\n", err)
+				logger.V(1).Info("failed to scan pod resources", "err", err)
 				condStatus = v1.ConditionFalse
 				podreadiness.SetCondition(condChan, podreadiness.PodresourcesFetched, condStatus)
 				continue
@@ -81,7 +82,7 @@ func (rm *ResourceObserver) Run(ctx context.Context, eventsChan <-chan notificat
 		case <-ctx.Done():
 			return
 		case <-rm.stopChan:
-			klog.Infof("read stop at %v", time.Now())
+			logger.Info("read stop", "at", time.Now())
 			return
 		}
 	}

--- a/pkg/resourcetopologyexporter/resourcetopologyexporter.go
+++ b/pkg/resourcetopologyexporter/resourcetopologyexporter.go
@@ -8,6 +8,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
+	"github.com/go-logr/logr"
 	topologyclientset "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned"
 
 	"github.com/k8stopologyawareschedwg/resource-topology-exporter/pkg/kubeconf"
@@ -68,7 +69,9 @@ type Handle struct {
 }
 
 func Execute(ctx context.Context, hnd Handle, nrtupdaterArgs nrtupdater.Args, resourcemonitorArgs resourcemonitor.Args, rteArgs Args) error {
-	tmConf, err := getTopologyManagerSettings(rteArgs)
+	logger := klog.FromContext(ctx)
+
+	tmConf, err := getTopologyManagerSettings(logger, rteArgs)
 	if err != nil {
 		return err
 	}
@@ -77,7 +80,7 @@ func Execute(ctx context.Context, hnd Handle, nrtupdaterArgs nrtupdater.Args, re
 	if rteArgs.AddNRTOwnerEnable {
 		nodeGetter, err = nrtupdater.NewCachedNodeGetter(hnd.ResMon.K8SCli, ctx)
 		if err != nil {
-			klog.V(2).Info("Cannot enable 'add-nrt-owner'. Unable to get node info")
+			logger.V(2).Info("Cannot enable 'add-nrt-owner'. Unable to get node info")
 			return fmt.Errorf("Cannot enable 'add-nrt-owner'. %w", err)
 		}
 	} else {
@@ -156,7 +159,7 @@ func createEventSource(rteArgs *Args) (notification.EventSource, error) {
 	return es, nil
 }
 
-func getTopologyManagerSettings(rteArgs Args) (tmSettings, error) {
+func getTopologyManagerSettings(logger logr.Logger, rteArgs Args) (tmSettings, error) {
 	if rteArgs.TopologyManagerPolicy != "" && rteArgs.TopologyManagerScope != "" {
 		tmConf := tmSettings{
 			config: nrtupdater.TMConfig{
@@ -164,7 +167,7 @@ func getTopologyManagerSettings(rteArgs Args) (tmSettings, error) {
 				Scope:  rteArgs.TopologyManagerScope,
 			},
 		}
-		klog.Infof("using given Topology Manager policy %q scope %q", tmConf.config.Policy, tmConf.config.Scope)
+		logger.Info("using given Topology Manager settings", "policy", tmConf.config.Policy, "scope", tmConf.config.Scope)
 		return tmConf, nil
 	}
 	if rteArgs.KubeletConfigFile != "" {
@@ -178,7 +181,7 @@ func getTopologyManagerSettings(rteArgs Args) (tmSettings, error) {
 				Scope:  klConfig.TopologyManagerScope,
 			},
 		}
-		klog.Infof("using detected Topology Manager policy %q scope %q", tmConf.config.Policy, tmConf.config.Scope)
+		logger.Info("using detected Topology Manager settings", "policy", tmConf.config.Policy, "scope", tmConf.config.Scope)
 		return tmConf, nil
 	}
 	return tmSettings{}, fmt.Errorf("cannot find the kubelet Topology Manager policy")


### PR DESCRIPTION
We can and should get the logger from the context. Includes some minor resourcemonitor fixes.