### PR TITLE
resmon: detect and expose non-topology-aware resources via NRT attribute

### DIFF
--- a/pkg/resourcemonitor/resourcemonitor.go
+++ b/pkg/resourcemonitor/resourcemonitor.go
@@ -443,6 +443,22 @@ func (rm *resourceMonitor) Scan(ctx context.Context, excludeList ResourceExclude
 
 		zones = append(zones, zone)
 	}
+
+	if rm.nonTopologyResources.Len() > 0 {
+		resNames := make([]string, 0, rm.nonTopologyResources.Len())
+		for resName := range rm.nonTopologyResources {
+			if inExcludeSet(excludeSet, resName, rm.nodeName) {
+				continue
+			}
+			resNames = append(resNames, resName.String())
+		}
+		sort.Strings(resNames)
+		scanRes.Attributes = append(scanRes.Attributes, topologyv1alpha2.AttributeInfo{
+			Name:  AttributeNodeNonTopologyResources,
+			Value: strings.Join(resNames, ","),
+		})
+	}
+
 	scanRes.Zones = zones
 	return scanRes, nil
 }

--- a/pkg/resourcemonitor/resourcemonitor.go
+++ b/pkg/resourcemonitor/resourcemonitor.go
@@ -29,6 +29,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -239,7 +240,7 @@ func (rm *resourceMonitor) Setup(ctx context.Context) error {
 	rm.coreIDToNodeIDMap = MakeCoreIDToNodeIDMap(rm.topo)
 	logger.V(4).Info("CPU mapping", "coreIDToNodeID", mapIntIntToString(rm.coreIDToNodeIDMap))
 
-	if err := rm.updateNodeResources(ctx); err != nil {
+	if err := rm.updateNodeResources(ctx, nil); err != nil {
 		return err
 	}
 	logger.V(2).Info("initial capacity", "capacity", rm.nodeCapacity)
@@ -536,7 +537,7 @@ func (rm *resourceMonitor) resUpdated(ctx context.Context, old, new any) {
 	if !reflect.DeepEqual(nOld.Status.Capacity, nNew.Status.Capacity) ||
 		!reflect.DeepEqual(nOld.Status.Allocatable, nNew.Status.Allocatable) {
 		logger.V(2).Info("update node resources")
-		if err := rm.updateNodeResources(ctx); err != nil {
+		if err := rm.updateNodeResources(ctx, nNew); err != nil {
 			logger.Error(err, "while updating node resources")
 		}
 	}
@@ -570,7 +571,8 @@ func (rm *resourceMonitor) updateDevicesCapacity() {
 	}
 }
 
-func (rm *resourceMonitor) updateNodeResources(ctx context.Context) error {
+func (rm *resourceMonitor) updateNodeResources(ctx context.Context, node *v1.Node) error {
+	logger := klog.FromContext(ctx)
 	if err := rm.updateNodeCapacity(); err != nil {
 		return fmt.Errorf("error while updating node capacity: %w", err)
 	}
@@ -580,7 +582,49 @@ func (rm *resourceMonitor) updateNodeResources(ctx context.Context) error {
 	// there is no trivial way to detect devices capacity from the node.
 	// hence, initialize capacity as allocatable
 	rm.updateDevicesCapacity()
+	if node == nil {
+		var err error
+		node, err = rm.getLocalNode(ctx)
+		if err != nil {
+			logger.V(1).Info("error fetching local node, continuing without non-device-plugin resource detection", "err", err)
+			return nil
+		}
+	}
+	rm.detectNonDevicePluginResources(logger, node)
 	return nil
+}
+
+func (rm *resourceMonitor) getLocalNode(ctx context.Context) (*v1.Node, error) {
+	nodes, err := rm.k8sCli.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("metadata.name=%s", rm.nodeName),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(nodes.Items) == 0 {
+		return nil, fmt.Errorf("node %q not found", rm.nodeName)
+	}
+	return &nodes.Items[0], nil
+}
+
+func (rm *resourceMonitor) detectNonDevicePluginResources(logger logr.Logger, node *v1.Node) {
+	knownResources := sets.New[v1.ResourceName]()
+	for _, rc := range rm.nodeAllocatable {
+		for name := range rc {
+			knownResources.Insert(name)
+		}
+	}
+	knownResources = knownResources.Union(rm.nonTopologyResources)
+	for name := range node.Status.Allocatable {
+		if isNativeResource(name) {
+			continue
+		}
+		if knownResources.Has(name) {
+			continue
+		}
+		rm.nonTopologyResources.Insert(name)
+		logger.V(4).Info("detected non-device-plugin resource", "resource", name)
+	}
 }
 
 // computePodFingerprintFromPodResources computes the pod fingerprint from the given pod resources after applying the filter function to the pod resources.

--- a/pkg/resourcemonitor/resourcemonitor.go
+++ b/pkg/resourcemonitor/resourcemonitor.go
@@ -59,6 +59,9 @@ const (
 
 	TopologyManagerPolicySingleNUMANode = "single-numa-node"
 
+	// AttributeNodeNonTopologyResources is the attribute name for resources which are not topology aware or not bound to any NUMA node on the node.
+	AttributeNodeNonTopologyResources = "nodeNonTopologyResources"
+
 	unsupportedConfigurationForNumaPlacement = "unsupported"
 	errorOccurredDuringNumaPlacementEncoding = "error occurred"
 )
@@ -181,16 +184,17 @@ func (nrc perNUMAResourceCounter) String() string {
 }
 
 type resourceMonitor struct {
-	nodeName          string
-	args              Args
-	tmPolicy          string
-	podResCli         podresourcesapi.PodResourcesListerClient
-	k8sCli            kubernetes.Interface
-	topo              *ghwtopology.Info
-	coreIDToNodeIDMap map[int]int
-	nodeCapacity      perNUMAResourceCounter
-	nodeAllocatable   perNUMAResourceCounter
-	scanIteration     uint64
+	nodeName             string
+	args                 Args
+	tmPolicy             string
+	podResCli            podresourcesapi.PodResourcesListerClient
+	k8sCli               kubernetes.Interface
+	topo                 *ghwtopology.Info
+	coreIDToNodeIDMap    map[int]int
+	nodeCapacity         perNUMAResourceCounter
+	nodeAllocatable      perNUMAResourceCounter
+	nonTopologyResources sets.Set[v1.ResourceName]
+	scanIteration        uint64
 }
 
 func NewResourceMonitor(hnd Handle, args Args, tmPolicy string, options ...func(*resourceMonitor)) *resourceMonitor {
@@ -550,6 +554,7 @@ func (rm *resourceMonitor) updateNodeAllocatable(ctx context.Context) error {
 
 	allDevs := NormalizeContainerDevices(logger, allocRes.GetDevices(), allocRes.GetMemory(), allocRes.GetCpuIds(), rm.coreIDToNodeIDMap)
 	rm.nodeAllocatable = ContainerDevicesToPerNUMAResourceCounters(logger, allDevs)
+	rm.nonTopologyResources = collectNonTopologyResourceNames(logger, allDevs)
 	return nil
 }
 
@@ -712,6 +717,22 @@ func ContainerDevicesToPerNUMAResourceCounters(logger logr.Logger, devices []*po
 	}
 	logger.V(6).Info("container devices to per-NUMA resource counters", "devices", len(devices), "counters", perNUMARc.String())
 	return perNUMARc
+}
+
+func collectNonTopologyResourceNames(logger logr.Logger, devices []*podresourcesapi.ContainerDevices) sets.Set[v1.ResourceName] {
+	res := sets.New[v1.ResourceName]()
+	for _, device := range devices {
+		if len(numaloclib.GetNUMAIDs(device.GetTopology())) > 0 {
+			continue
+		}
+		resName := v1.ResourceName(device.GetResourceName())
+		if isNativeResource(resName) {
+			continue
+		}
+		res.Insert(resName)
+	}
+	logger.V(6).Info("non-topology resource names from device plugins", "resources", res)
+	return res
 }
 
 func MakeCoreIDToNodeIDMap(topo *ghwtopology.Info) map[int]int {

--- a/pkg/resourcemonitor/resourcemonitor_test.go
+++ b/pkg/resourcemonitor/resourcemonitor_test.go
@@ -1874,6 +1874,77 @@ func TestCollectNonTopologyResourceNames(t *testing.T) {
 	}
 }
 
+func TestDetectNonDevicePluginResources(t *testing.T) {
+	logger := logr.Discard()
+
+	testCases := []struct {
+		name                 string
+		nodeAllocatable      perNUMAResourceCounter
+		nonTopologyResources sets.Set[corev1.ResourceName]
+		nodeStatus           corev1.ResourceList
+		expected             sets.Set[corev1.ResourceName]
+	}{
+		{
+			name: "detects resources not in device plugins",
+			nodeAllocatable: perNUMAResourceCounter{
+				0: resourceCounter{"fake.io/net": 4},
+			},
+			nonTopologyResources: sets.New[corev1.ResourceName](),
+			nodeStatus: corev1.ResourceList{
+				"cpu":                                    resource.MustParse("24"),
+				"memory":                                 resource.MustParse("64Gi"),
+				"fake.io/net":                            resource.MustParse("4"),
+				"management.workload.openshift.io/cores": resource.MustParse("4000"),
+				"another.example.com/resource-without-dp": resource.MustParse("10"),
+			},
+			expected: sets.New[corev1.ResourceName](
+				"management.workload.openshift.io/cores",
+				"another.example.com/resource-without-dp",
+			),
+		},
+		{
+			name: "does not duplicate already known non-topology resources",
+			nodeAllocatable: perNUMAResourceCounter{
+				0: resourceCounter{"fake.io/net": 4},
+			},
+			nonTopologyResources: sets.New[corev1.ResourceName]("fake.io/notopo"),
+			nodeStatus: corev1.ResourceList{
+				"cpu":            resource.MustParse("24"),
+				"fake.io/net":    resource.MustParse("4"),
+				"fake.io/notopo": resource.MustParse("2"),
+			},
+			expected: sets.New[corev1.ResourceName]("fake.io/notopo"),
+		},
+		{
+			name:                 "no extended resources on node",
+			nodeAllocatable:      perNUMAResourceCounter{},
+			nonTopologyResources: sets.New[corev1.ResourceName](),
+			nodeStatus: corev1.ResourceList{
+				"cpu":    resource.MustParse("24"),
+				"memory": resource.MustParse("64Gi"),
+			},
+			expected: sets.New[corev1.ResourceName](),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rm := &resourceMonitor{
+				nodeAllocatable:      tc.nodeAllocatable,
+				nonTopologyResources: tc.nonTopologyResources,
+			}
+			node := &corev1.Node{
+				Status: corev1.NodeStatus{
+					Allocatable: tc.nodeStatus,
+				},
+			}
+			rm.detectNonDevicePluginResources(logger, node)
+			assert.True(t, tc.expected.Equal(rm.nonTopologyResources),
+				"expected %v, got %v", tc.expected, rm.nonTopologyResources)
+		})
+	}
+}
+
 // ghwc topology -f json
 var testTopology string = `{
     "nodes": [

--- a/pkg/resourcemonitor/resourcemonitor_test.go
+++ b/pkg/resourcemonitor/resourcemonitor_test.go
@@ -24,7 +24,9 @@ import (
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 	v1 "k8s.io/kubelet/pkg/apis/podresources/v1"
@@ -1755,6 +1757,120 @@ func getExpectedCoreToNodeMap() map[int]int {
 		19: 1,
 		21: 1,
 		23: 1,
+	}
+}
+
+func TestCollectNonTopologyResourceNames(t *testing.T) {
+	logger := logr.Discard()
+
+	testCases := []struct {
+		name     string
+		devices  []*podresourcesapi.ContainerDevices
+		expected sets.Set[corev1.ResourceName]
+	}{
+		{
+			name:     "empty devices",
+			devices:  []*podresourcesapi.ContainerDevices{},
+			expected: sets.New[corev1.ResourceName](),
+		},
+		{
+			name: "devices with NUMA topology are excluded",
+			devices: []*podresourcesapi.ContainerDevices{
+				{
+					ResourceName: "fake.io/net",
+					DeviceIds:    []string{"net-0"},
+					Topology: &podresourcesapi.TopologyInfo{
+						Nodes: []*podresourcesapi.NUMANode{{ID: 0}},
+					},
+				},
+			},
+			expected: sets.New[corev1.ResourceName](),
+		},
+		{
+			name: "devices with nil topology are captured",
+			devices: []*podresourcesapi.ContainerDevices{
+				{
+					ResourceName: "fake.io/notopo",
+					DeviceIds:    []string{"dev-0"},
+					Topology:     nil,
+				},
+			},
+			expected: sets.New[corev1.ResourceName]("fake.io/notopo"),
+		},
+		{
+			name: "devices with empty nodes are captured",
+			devices: []*podresourcesapi.ContainerDevices{
+				{
+					ResourceName: "fake.io/emptynodes",
+					DeviceIds:    []string{"dev-0"},
+					Topology: &podresourcesapi.TopologyInfo{
+						Nodes: []*podresourcesapi.NUMANode{},
+					},
+				},
+			},
+			expected: sets.New[corev1.ResourceName]("fake.io/emptynodes"),
+		},
+		{
+			name: "devices with ID -1 are captured",
+			devices: []*podresourcesapi.ContainerDevices{
+				{
+					ResourceName: "fake.io/dontcare",
+					DeviceIds:    []string{"dev-0"},
+					Topology: &podresourcesapi.TopologyInfo{
+						Nodes: []*podresourcesapi.NUMANode{{ID: -1}},
+					},
+				},
+			},
+			expected: sets.New[corev1.ResourceName]("fake.io/dontcare"),
+		},
+		{
+			name: "native resources are excluded",
+			devices: []*podresourcesapi.ContainerDevices{
+				{
+					ResourceName: "cpu",
+					DeviceIds:    []string{"0"},
+					Topology:     nil,
+				},
+				{
+					ResourceName: "memory",
+					DeviceIds:    []string{"1024"},
+					Topology:     nil,
+				},
+			},
+			expected: sets.New[corev1.ResourceName](),
+		},
+		{
+			name: "mixed devices with and without topology",
+			devices: []*podresourcesapi.ContainerDevices{
+				{
+					ResourceName: "fake.io/with-topo",
+					DeviceIds:    []string{"dev-0"},
+					Topology: &podresourcesapi.TopologyInfo{
+						Nodes: []*podresourcesapi.NUMANode{{ID: 0}},
+					},
+				},
+				{
+					ResourceName: "fake.io/no-topo",
+					DeviceIds:    []string{"dev-1"},
+					Topology:     nil,
+				},
+				{
+					ResourceName: "fake.io/also-no-topo",
+					DeviceIds:    []string{"dev-2"},
+					Topology: &podresourcesapi.TopologyInfo{
+						Nodes: []*podresourcesapi.NUMANode{{ID: -1}},
+					},
+				},
+			},
+			expected: sets.New[corev1.ResourceName]("fake.io/no-topo", "fake.io/also-no-topo"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := collectNonTopologyResourceNames(logger, tc.devices)
+			assert.True(t, tc.expected.Equal(result), "expected %v, got %v", tc.expected, result)
+		})
 	}
 }
 

--- a/pkg/resourcemonitor/resourcemonitor_test.go
+++ b/pkg/resourcemonitor/resourcemonitor_test.go
@@ -1945,6 +1945,67 @@ func TestDetectNonDevicePluginResources(t *testing.T) {
 	}
 }
 
+func TestScanNonTopologyResourcesAttribute(t *testing.T) {
+	fakeTopo := ghwtopology.Info{}
+	assert.NoError(t, json.Unmarshal([]byte(testTopology), &fakeTopo))
+
+	devicesWithTopo := getAllContainerDevices()
+	devicesWithNoTopo := append(devicesWithTopo,
+		&v1.ContainerDevices{
+			ResourceName: "fake.io/notopo-a",
+			DeviceIds:    []string{"dev-0", "dev-1"},
+			Topology:     nil,
+		},
+		&v1.ContainerDevices{
+			ResourceName: "fake.io/notopo-b",
+			DeviceIds:    []string{"dev-x"},
+			Topology:     nil,
+		},
+	)
+
+	availRes := &v1.AllocatableResourcesResponse{
+		Devices: devicesWithNoTopo,
+		CpuIds: []int64{
+			0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+			12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+		},
+	}
+
+	mockPodResClient := new(podres.MockPodResourcesListerClient)
+	mockPodResClient.On("GetAllocatableResources", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.AllocatableResourcesRequest")).Return(availRes, nil)
+	resMon := NewResourceMonitor(
+		Handle{PodResCli: mockPodResClient},
+		Args{},
+		"",
+		WithNodeName("TEST"),
+		WithTopology(&fakeTopo),
+		WithK8sClient(fake.NewSimpleClientset()),
+	)
+	err := resMon.Setup(context.TODO())
+	assert.NoError(t, err)
+
+	resp := &v1.ListPodResourcesResponse{
+		PodResources: []*v1.PodResources{},
+	}
+	mockPodResClient.On("List", mock.AnythingOfType("*context.timerCtx"), mock.AnythingOfType("*v1.ListPodResourcesRequest")).Return(resp, nil)
+
+	scanRes, err := resMon.Scan(context.TODO(), ResourceExclude{})
+	assert.NoError(t, err)
+
+	var foundAttr *topologyv1alpha2.AttributeInfo
+	for i := range scanRes.Attributes {
+		if scanRes.Attributes[i].Name == AttributeNodeNonTopologyResources {
+			foundAttr = &scanRes.Attributes[i]
+			break
+		}
+	}
+	assert.NotNil(t, foundAttr, "nodeNonTopologyResources attribute should be present")
+
+	resNames := strings.Split(foundAttr.Value, ",")
+	sort.Strings(resNames)
+	assert.Equal(t, []string{"fake.io/notopo-a", "fake.io/notopo-b"}, resNames)
+}
+
 // ghwc topology -f json
 var testTopology string = `{
     "nodes": [


### PR DESCRIPTION
Some extended resources on a node are not tied to any NUMA node -- either because the device plugin reports them without topology information, or because they aren't backed by a device plugin at all.

Today RTE silently ignores these resources, making them invisible to topology-aware schedulers.

This PR detects both kinds and exposes their names as a new top-level NRT attribute `nodeNonTopologyResources`, so scheduler-plugins can identify and exclude them from NUMA-aware scheduling decisions.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>